### PR TITLE
Bugfix/wrong date

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # org.gradle.parallel=true
 
 GROUP=com.prolificinteractive
-VERSION_NAME=0.2.1
+VERSION_NAME=0.2.2-SNAPSHOT
 VERSION_CODE=2
 
 POM_PACKAGING=aar

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarUtils.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarUtils.java
@@ -15,8 +15,14 @@ public class CalendarUtils {
 
     public static Calendar getInstance(Date date) {
         Calendar calendar = Calendar.getInstance();
-        calendar.setTime(date);
-        copyDateTo(calendar, calendar);
+        if(date != null) {
+            calendar.setTime(date);
+        }
+        int year = getYear(calendar);
+        int month = getMonth(calendar);
+        int day = getDay(calendar);
+        calendar.clear();
+        calendar.set(year, month, day);
         return calendar;
     }
 

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarUtils.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarUtils.java
@@ -13,6 +13,9 @@ import static java.util.Calendar.YEAR;
  */
 public class CalendarUtils {
 
+    /**
+     * @return a new Calendar instance with the date set to the provided date. Time set to zero.
+     */
     public static Calendar getInstance(Date date) {
         Calendar calendar = Calendar.getInstance();
         if(date != null) {
@@ -26,12 +29,18 @@ public class CalendarUtils {
         return calendar;
     }
 
+    /**
+     * @return a new Calendar instance with the date set to today. Time set to zero.
+     */
     public static Calendar getInstance() {
         Calendar calendar = Calendar.getInstance();
         copyDateTo(calendar, calendar);
         return calendar;
     }
 
+    /**
+     * Set the provided calendar to the first day of the month. Also clears all time information.
+     */
     public static void setToFirstDay(Calendar calendar) {
         int year = getYear(calendar);
         int month = getMonth(calendar);
@@ -40,6 +49,9 @@ public class CalendarUtils {
         calendar.getTimeInMillis();
     }
 
+    /**
+     * Copy <i>only</i> date information to a new calendar.
+     */
     public static void copyDateTo(Calendar from, Calendar to) {
         to.clear();
         to.set(

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -351,6 +351,14 @@ public class MaterialCalendarView extends FrameLayout {
     }
 
     /**
+     * @param date set the minimum selectable date, null for no minimum
+     */
+    public void setMinimumDate(Date date) {
+        setMinimumDate(date == null ? null : new CalendarDay(date));
+        setRangeDates(minDate, maxDate);
+    }
+
+    /**
      * @param calendar set the minimum selectable date, null for no minimum
      */
     public void setMinimumDate(CalendarDay calendar) {
@@ -370,6 +378,14 @@ public class MaterialCalendarView extends FrameLayout {
      */
     public void setMaximumDate(Calendar calendar) {
         setMaximumDate(calendar == null ? null : new CalendarDay(calendar));
+        setRangeDates(minDate, maxDate);
+    }
+
+    /**
+     * @param date set the maximum selectable date, null for no maximum
+     */
+    public void setMaximumDate(Date date) {
+        setMaximumDate(date == null ? null : new CalendarDay(date));
         setRangeDates(minDate, maxDate);
     }
 

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/RangeActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/RangeActivity.java
@@ -31,13 +31,13 @@ public class RangeActivity extends ActionBarActivity implements OnDateChangedLis
         widget.setOnDateChangedListener(this);
 
         Calendar calendar = Calendar.getInstance();
-        widget.setSelectedDate(calendar);
+        widget.setSelectedDate(calendar.getTime());
 
         calendar.set(calendar.get(Calendar.YEAR), Calendar.JANUARY, 1);
-        widget.setMinimumDate(calendar);
+        widget.setMinimumDate(calendar.getTime());
 
         calendar.set(calendar.get(Calendar.YEAR) + 2, Calendar.OCTOBER, 31);
-        widget.setMaximumDate(calendar);
+        widget.setMaximumDate(calendar.getTime());
     }
 
     @Override


### PR DESCRIPTION
Fix for issue #5. The `CalendarUtils.getInstance(Date)` didn't copy date information correctly. This PR also adds some documentation.