### PR TITLE
Make build config jitpack friendly

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,6 +34,16 @@ signing {
    sign configurations.archives
 }
 
+def getReleaseRepositoryUrl() {
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
 def getRepositoryUsername() {
   return hasProperty('sonatypeUsername') ? sonatypeUsername : ""
 }
@@ -46,13 +56,13 @@ uploadArchives {
   repositories.mavenDeployer {
     beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-    repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+    repository(url: getReleaseRepositoryUrl()) {
       authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
     }
 
-    snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-      authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-    }
+      snapshotRepository(url: getSnapshotRepositoryUrl()) {
+          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+      }
 
     pom.groupId = GROUP
     pom.version = version


### PR DESCRIPTION
With these changes, you can use JitPack to obtain a build for a specific commit which is especially useful if you fork the library and want to test the changes outside of the sample app.