### PR TITLE
Initialize decorators to empty list

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -900,7 +900,7 @@ public class MaterialCalendarView extends FrameLayout {
         private CalendarDay selectedDate = null;
         private WeekDayFormatter weekDayFormatter = WeekDayFormatter.DEFAULT;
         private DayFormatter dayFormatter = DayFormatter.DEFAULT;
-        private List<DayViewDecorator> decorators = null;
+        private List<DayViewDecorator> decorators = new ArrayList<>();
         private List<DecoratorResult> decoratorResults = null;
         private int firstDayOfTheWeek = Calendar.SUNDAY;
 


### PR DESCRIPTION
This prevents NPEs in remove/invalidate decorator methods if called before any decorators have been added to the calendar.

`MaterialCalendarView.dayViewDecorators` is already initialized to an empty `ArrayList` so this makes `MonthPagerAdapter` consistent with that.