### PR TITLE
Overloaded setCurrentDate with setCurrentDate(CalendarDay day, boolea…

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -517,11 +517,19 @@ public class MaterialCalendarView extends FrameLayout {
      * @param day a CalendarDay to focus the calendar on. Null will do nothing
      */
     public void setCurrentDate(@Nullable CalendarDay day) {
+        setCurrentDate(day, true);
+    }
+
+    /**
+     * @param day a CalendarDay to focus the calendar on. Null will do nothing
+     * @param useSmoothScroll use smooth scroll when changing months.
+     */
+    public void setCurrentDate(@Nullable CalendarDay day, boolean useSmoothScroll) {
         if(day == null) {
             return;
         }
         int index = adapter.getIndexForDay(day);
-        pager.setCurrentItem(index);
+        pager.setCurrentItem(index, useSmoothScroll);
         updateUi();
     }
 


### PR DESCRIPTION
…n useSmoothScroll). **Use Case:** When setting the date programmatically it may not always be desired that the ViewPager animates month changes.

*To go into a little more detail about why I added this method...*

I'm currently developing an app that is similar to the Calendar app which has a toggle-able MaterialCalendarView to help navigate a RecyclerView. When hidden the Recycler controls the calendar, and when visible the calendar controls the Recycler. Unfortunately updating the hidden calendar date to match the Recycler during a Recycler scroll impacts scroll performance, thus I have opted to update the calendar date when opening or expanding the calendar. In some cases this results in the user seeing several months slide by as the calendar expands. Adding a method to opt-out of smooth scroll solves this.

If this pull is added to the library it may be worth considering if the other setCurrentDate methods with Date and Calendar arguments should be overloaded also.