### PR TITLE
Fix issue where month representations weren't being generated correctly

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarDay.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarDay.java
@@ -181,6 +181,12 @@ public final class CalendarDay implements Parcelable {
         return _calendar;
     }
 
+    void copyToMonthOnly(@NonNull Calendar calendar) {
+        calendar.clear();
+        calendar.set(year, month, 1);
+        calendar.getTimeInMillis();
+    }
+
     /**
      * Copy this day's information to the given calendar instance
      *
@@ -189,6 +195,7 @@ public final class CalendarDay implements Parcelable {
     public void copyTo(@NonNull Calendar calendar) {
         calendar.clear();
         calendar.set(year, month, day);
+        calendar.getTimeInMillis();
     }
 
     /**

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -1138,16 +1138,18 @@ public class MaterialCalendarView extends FrameLayout {
                 max = CalendarDay.from(worker);
             }
 
-            Calendar worker = CalendarUtils.getInstance();
-            min.copyTo(worker);
-            CalendarUtils.setToFirstDay(worker);
             months.clear();
+
+            Calendar worker = CalendarUtils.getInstance();
+            min.copyToMonthOnly(worker);
             CalendarDay workingMonth = CalendarDay.from(worker);
             while (!max.isBefore(workingMonth)) {
                 months.add(CalendarDay.from(worker));
                 worker.add(Calendar.MONTH, 1);
+                worker.set(Calendar.DAY_OF_MONTH, 1);
                 workingMonth = CalendarDay.from(worker);
             }
+
             CalendarDay prevDate = selectedDate;
             notifyDataSetChanged();
             setSelectedDate(prevDate);


### PR DESCRIPTION
This should fix issue #74. @sersast @gusdn9 @jlindenbaum can any of you try out the a snapshot build `'com.prolificinteractive:material-calendarview:0.7.0-SNAPSHOT'` to verify this fixes the issue?

Reviewers: @ireneduke @chahinem 