### PR TITLE
Auto-detect first day-of-week

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * <p>
@@ -224,7 +225,7 @@ public class MaterialCalendarView extends FrameLayout {
             ));
             setFirstDayOfWeek(a.getInt(
                     R.styleable.MaterialCalendarView_mcv_firstDayOfWeek,
-                    Calendar.SUNDAY
+                    Calendar.getInstance(Locale.getDefault()).getFirstDayOfWeek()
             ));
         }
         catch (Exception e) {

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -223,10 +223,15 @@ public class MaterialCalendarView extends FrameLayout {
                     R.styleable.MaterialCalendarView_mcv_showOtherDates,
                     false
             ));
-            setFirstDayOfWeek(a.getInt(
+
+            int firstDayOfWeek = a.getInt(
                     R.styleable.MaterialCalendarView_mcv_firstDayOfWeek,
-                    Calendar.getInstance(Locale.getDefault()).getFirstDayOfWeek()
-            ));
+                    -1
+            );
+            if(firstDayOfWeek < 0) {
+                firstDayOfWeek = CalendarUtils.getInstance().getFirstDayOfWeek();
+            }
+            setFirstDayOfWeek(firstDayOfWeek);
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Current default is `Calendar.SUNDAY` unless otherwise specified. [`Calendar.getFirstDayOfWeek()`](http://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#getFirstDayOfWeek()) can figure this out in a locale aware way.