### PR TITLE
Custom View Optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Change Log
 ==========
 
+Version FUTURE *(RELEASE_DATE)*
+-------------------------------
+
+* Change: The view now responds better to layout parameters.
+The functionality is similar to how `adjustViewBounds` works with ImageView,
+where the view will try and take up as much space as necessary,
+but we base it on tile size instead of an aspect ratio.
+The exception being that if a `tileSize` is set,
+that will override everything and set the view to that size.
+
 Version 0.7.0 *(2015-07-09)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ and feel, rather than 100% parity with the platform's implementation.
 
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Material%20Calendar%20View-blue.svg?style=flat)](https://android-arsenal.com/details/1/1531)
 
+Breaking Change in FUTURE *(RELEASE_DATE)*
+------------------------------------------
+
+* Change: The view now responds better to layout parameters.
+The functionality is similar to how `adjustViewBounds` works with ImageView,
+where the view will try and take up as much space as necessary,
+but we base it on tile size instead of an aspect ratio.
+The exception being that if a `tileSize` is set,
+that will override everything and set the view to that size.
+
 Usage
 -----
 
@@ -93,15 +103,6 @@ If one of your decorators changes after it's been added to the calendar view, ma
 When implementing a `DayViewDecorator`, make sure that they are as efficent as possible.
 Remember that `shouldDecorate()` needs to be called 42 times for each month view.
 An easy way to be more efficent is to convert your data to `CalendarDay`s outside of `shouldDecorate()`.
-
-#### Migrating from 0.3.x
-
-To make decorating more efficent, the following changes were made to `DayViewFacade`:
-
-* Removed `getDate()`. Decorations to a facade will be applied to all days for the decorator. Use multiple decorators for different decorating.
-* Replaced `setBackground()` with `setSelectionBackground()` to be more clear on functionality.
-* Replaced `setBackgroundUnselected()` with `setBackgroundDrawable()`. The drawable will now be draw below everything else on the day view.
-* Removed `setText()`. Instead you should use `addSpan()` to add a span to the entire day label. See above for information on spans.
 
 Contributing
 ============

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -238,6 +238,18 @@ public class MaterialCalendarView extends FrameLayout {
 
         currentMonth = CalendarDay.today();
         setCurrentDate(currentMonth);
+
+        if(isInEditMode()) {
+            removeView(pager);
+            MonthView monthView = new MonthView(context, currentMonth, getFirstDayOfWeek());
+            monthView.setSelectionColor(getSelectionColor());
+//            monthView.setWeekDayFormatter(weekDayFormatter);
+//            monthView.setDayFormatter(dayFormatter);
+            monthView.setDateTextAppearance(adapter.getDateTextAppearance());
+            monthView.setWeekDayTextAppearance(adapter.getWeekDayTextAppearance());
+            monthView.setShowOtherDates(getShowOtherDates());
+            addView(monthView, new LayoutParams(MonthView.DEFAULT_MONTH_TILE_HEIGHT));
+        }
     }
 
     private void setupChildren() {
@@ -380,7 +392,12 @@ public class MaterialCalendarView extends FrameLayout {
      */
     public void setSelectionColor(int color) {
         if(color == 0) {
-            return;
+            if(!isInEditMode()) {
+                return;
+            }
+            else {
+                color = Color.GRAY;
+            }
         }
         accentColor = color;
         adapter.setSelectionColor(color);

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -251,8 +251,6 @@ public class MaterialCalendarView extends ViewGroup {
             removeView(pager);
             MonthView monthView = new MonthView(context, currentMonth, getFirstDayOfWeek());
             monthView.setSelectionColor(getSelectionColor());
-//            monthView.setWeekDayFormatter(weekDayFormatter);
-//            monthView.setDayFormatter(dayFormatter);
             monthView.setDateTextAppearance(adapter.getDateTextAppearance());
             monthView.setWeekDayTextAppearance(adapter.getWeekDayTextAppearance());
             monthView.setShowOtherDates(getShowOtherDates());
@@ -748,14 +746,12 @@ public class MaterialCalendarView extends ViewGroup {
 
     @Override
     protected void dispatchSaveInstanceState(@NonNull SparseArray<Parcelable> container) {
-        //super.dispatchSaveInstanceState(container);
-        super.dispatchFreezeSelfOnly(container);
+        dispatchFreezeSelfOnly(container);
     }
 
     @Override
     protected void dispatchRestoreInstanceState(@NonNull SparseArray<Parcelable> container) {
-        //super.dispatchRestoreInstanceState(container);
-        super.dispatchThawSelfOnly(container);
+        dispatchThawSelfOnly(container);
     }
 
     private void setRangeDates(CalendarDay min, CalendarDay max) {

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -137,8 +137,15 @@ public class MaterialCalendarView extends ViewGroup {
     public MaterialCalendarView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        setClipChildren(false);
-        setClipToPadding(false);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            //If we're on good Android versions, turn off clipping for cool effects
+            setClipToPadding(false);
+            setClipChildren(false);
+        } else {
+            //Old Android does not like _not_ clipping view pagers, we need to clip
+            setClipChildren(true);
+            setClipToPadding(true);
+        }
 
         buttonPast = new DirectionButton(getContext());
         title = new TextView(getContext());

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -9,14 +9,12 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.ArrayRes;
 import android.support.annotation.Nullable;
-import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -34,9 +32,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * <p>
@@ -149,7 +145,7 @@ public class MaterialCalendarView extends FrameLayout {
 
         titleChanger = new TitleChanger(title);
         titleChanger.setTitleFormatter(DEFAULT_TITLE_FORMATTER);
-        adapter = new MonthPagerAdapter(this);
+        adapter = new MonthPagerAdapter();
         pager.setAdapter(adapter);
         pager.setOnPageChangeListener(pageChangeListener);
         pager.setPageTransformer(false, new ViewPager.PageTransformer() {
@@ -923,292 +919,5 @@ public class MaterialCalendarView extends FrameLayout {
      */
     public void invalidateDecorators() {
         adapter.invalidateDecorators();
-    }
-
-    private static class MonthPagerAdapter extends PagerAdapter {
-
-        private final MaterialCalendarView view;
-        private final LinkedList<MonthView> currentViews;
-        private final ArrayList<CalendarDay> months;
-
-        private MonthView.Callbacks callbacks = null;
-        private Integer color = null;
-        private Integer dateTextAppearance = null;
-        private Integer weekDayTextAppearance = null;
-        private Boolean showOtherDates = null;
-        private CalendarDay minDate = null;
-        private CalendarDay maxDate = null;
-        private CalendarDay selectedDate = null;
-        private WeekDayFormatter weekDayFormatter = WeekDayFormatter.DEFAULT;
-        private DayFormatter dayFormatter = DayFormatter.DEFAULT;
-        private List<DayViewDecorator> decorators = new ArrayList<>();
-        private List<DecoratorResult> decoratorResults = null;
-        private int firstDayOfTheWeek = Calendar.SUNDAY;
-
-
-        private MonthPagerAdapter(MaterialCalendarView view) {
-            this.view = view;
-            currentViews = new LinkedList<>();
-            months = new ArrayList<>();
-            setRangeDates(null, null);
-        }
-
-
-        public void setDecorators(List<DayViewDecorator> decorators){
-            this.decorators = decorators;
-            invalidateDecorators();
-        }
-
-        public void invalidateDecorators() {
-            decoratorResults = new ArrayList<>();
-            for(DayViewDecorator decorator : decorators) {
-                DayViewFacade facade = new DayViewFacade();
-                decorator.decorate(facade);
-                if(facade.isDecorated()) {
-                    decoratorResults.add(new DecoratorResult(decorator, facade));
-                }
-            }
-            for(MonthView monthView : currentViews) {
-                monthView.setDayViewDecorators(decoratorResults);
-            }
-        }
-
-        @Override
-        public int getCount() {
-            return months.size();
-        }
-
-        public int getIndexForDay(CalendarDay day) {
-            if(day == null) {
-                return getCount() / 2;
-            }
-            if(minDate != null && day.isBefore(minDate)) {
-                return 0;
-            }
-            if(maxDate != null && day.isAfter(maxDate)) {
-                return getCount() - 1;
-            }
-            for (int i = 0; i < months.size(); i++) {
-                CalendarDay month = months.get(i);
-                if (day.getYear() == month.getYear() && day.getMonth() == month.getMonth()) {
-                    return i;
-                }
-            }
-            return getCount() / 2;
-        }
-
-        @Override
-        public int getItemPosition(Object object) {
-            if(!(object instanceof MonthView)) {
-                return POSITION_NONE;
-            }
-            MonthView monthView = (MonthView) object;
-            CalendarDay month = monthView.getMonth();
-            if(month == null) {
-                return POSITION_NONE;
-            }
-            int index = months.indexOf(month);
-            if(index < 0) {
-                return POSITION_NONE;
-            }
-            return index;
-        }
-
-        @Override
-        public Object instantiateItem(ViewGroup container, int position) {
-            CalendarDay month = months.get(position);
-            MonthView monthView = new MonthView(container.getContext(), month, firstDayOfTheWeek);
-
-            monthView.setWeekDayFormatter(weekDayFormatter);
-            monthView.setDayFormatter(dayFormatter);
-            monthView.setCallbacks(callbacks);
-            if(color != null) {
-                monthView.setSelectionColor(color);
-            }
-            if(dateTextAppearance != null) {
-                monthView.setDateTextAppearance(dateTextAppearance);
-            }
-            if(weekDayTextAppearance != null) {
-                monthView.setWeekDayTextAppearance(weekDayTextAppearance);
-            }
-            if(showOtherDates != null) {
-                monthView.setShowOtherDates(showOtherDates);
-            }
-            monthView.setMinimumDate(minDate);
-            monthView.setMaximumDate(maxDate);
-            monthView.setSelectedDate(selectedDate);
-
-            container.addView(monthView);
-            currentViews.add(monthView);
-
-            monthView.setDayViewDecorators(decoratorResults);
-
-            return monthView;
-        }
-
-        public void setFirstDayOfWeek(int day) {
-            firstDayOfTheWeek = day;
-            for(MonthView monthView : currentViews) {
-                monthView.setFirstDayOfWeek(firstDayOfTheWeek);
-            }
-        }
-
-        @Override
-        public void destroyItem(ViewGroup container, int position, Object object) {
-            MonthView monthView = (MonthView) object;
-            currentViews.remove(monthView);
-            container.removeView(monthView);
-        }
-
-        @Override
-        public boolean isViewFromObject(View view, Object object) {
-            return view == object;
-        }
-
-        public void setCallbacks(MonthView.Callbacks callbacks) {
-            this.callbacks = callbacks;
-            for(MonthView monthView : currentViews) {
-                monthView.setCallbacks(callbacks);
-            }
-        }
-
-        public void setSelectionColor(int color) {
-            this.color = color;
-            for(MonthView monthView : currentViews) {
-                monthView.setSelectionColor(color);
-            }
-        }
-
-        public void setDateTextAppearance(int taId) {
-            if(taId == 0) {
-                return;
-            }
-            this.dateTextAppearance = taId;
-            for(MonthView monthView : currentViews) {
-                monthView.setDateTextAppearance(taId);
-            }
-        }
-
-        public void setShowOtherDates(boolean show) {
-            this.showOtherDates = show;
-            for(MonthView monthView : currentViews) {
-                monthView.setShowOtherDates(show);
-            }
-        }
-
-        public void setWeekDayFormatter(WeekDayFormatter formatter) {
-            this.weekDayFormatter = formatter;
-            for(MonthView monthView : currentViews) {
-                monthView.setWeekDayFormatter(formatter);
-            }
-        }
-
-        public void setDayFormatter(DayFormatter formatter) {
-            this.dayFormatter = formatter;
-            for(MonthView monthView : currentViews) {
-                monthView.setDayFormatter(formatter);
-            }
-        }
-
-        public boolean getShowOtherDates() {
-            return showOtherDates;
-        }
-
-        public void setWeekDayTextAppearance(int taId) {
-            if(taId == 0) {
-                return;
-            }
-            this.weekDayTextAppearance = taId;
-            for(MonthView monthView : currentViews) {
-                monthView.setWeekDayTextAppearance(taId);
-            }
-        }
-
-        public void setRangeDates(CalendarDay min, CalendarDay max) {
-            this.minDate = min;
-            this.maxDate = max;
-            for(MonthView monthView : currentViews) {
-                monthView.setMinimumDate(min);
-                monthView.setMaximumDate(max);
-            }
-
-            if(min == null) {
-                Calendar worker = CalendarUtils.getInstance();
-                worker.add(Calendar.YEAR, -200);
-                min = CalendarDay.from(worker);
-            }
-
-            if(max == null) {
-                Calendar worker = CalendarUtils.getInstance();
-                worker.add(Calendar.YEAR, 200);
-                max = CalendarDay.from(worker);
-            }
-
-            months.clear();
-
-            Calendar worker = CalendarUtils.getInstance();
-            min.copyToMonthOnly(worker);
-            CalendarDay workingMonth = CalendarDay.from(worker);
-            while (!max.isBefore(workingMonth)) {
-                months.add(CalendarDay.from(worker));
-                worker.add(Calendar.MONTH, 1);
-                worker.set(Calendar.DAY_OF_MONTH, 1);
-                workingMonth = CalendarDay.from(worker);
-            }
-
-            CalendarDay prevDate = selectedDate;
-            notifyDataSetChanged();
-            setSelectedDate(prevDate);
-            if(prevDate != null) {
-                if(!prevDate.equals(selectedDate)) {
-                    callbacks.onDateChanged(selectedDate);
-                }
-            }
-        }
-
-        public void setSelectedDate(@Nullable CalendarDay date) {
-            CalendarDay prevDate = selectedDate;
-            this.selectedDate = getValidSelectedDate(date);
-            for(MonthView monthView : currentViews) {
-                monthView.setSelectedDate(selectedDate);
-            }
-
-            if(date == null && prevDate != null) {
-                callbacks.onDateChanged(null);
-            }
-        }
-
-        private CalendarDay getValidSelectedDate(CalendarDay date) {
-            if(date == null) {
-                return null;
-            }
-            if(minDate != null && minDate.isAfter(date)) {
-                return minDate;
-            }
-            if(maxDate != null && maxDate.isBefore(date)) {
-                return maxDate;
-            }
-            return date;
-        }
-
-        public CalendarDay getItem(int position) {
-            return months.get(position);
-        }
-
-        public CalendarDay getSelectedDate() {
-            return selectedDate;
-        }
-
-        protected int getDateTextAppearance() {
-            return dateTextAppearance == null ? 0 : dateTextAppearance;
-        }
-
-        protected int getWeekDayTextAppearance() {
-            return weekDayTextAppearance == null ? 0 : weekDayTextAppearance;
-        }
-
-        public int getFirstDayOfWeek() {
-            return firstDayOfTheWeek;
-        }
     }
 }

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -261,8 +261,6 @@ public class MaterialCalendarView extends ViewGroup {
     }
 
     private void setupChildren() {
-        setClipChildren(false);
-        setClipToPadding(false);
 
         topbar = new LinearLayout(getContext());
         topbar.setOrientation(LinearLayout.HORIZONTAL);
@@ -1005,7 +1003,7 @@ public class MaterialCalendarView extends ViewGroup {
             LayoutParams p = (LayoutParams) child.getLayoutParams();
 
             int childWidthMeasureSpec = MeasureSpec.makeMeasureSpec(
-                    measuredWidth - getPaddingLeft() - getPaddingRight(),
+                    MonthView.DEFAULT_DAYS_IN_WEEK * measureTileSize,
                     MeasureSpec.EXACTLY
             );
 
@@ -1048,8 +1046,8 @@ public class MaterialCalendarView extends ViewGroup {
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         final int count = getChildCount();
 
-        final int parentWidth = right - left;
         final int parentLeft = getPaddingLeft();
+        final int parentWidth = right - left - parentLeft - getPaddingRight();
 
         int childTop = getPaddingTop();
 
@@ -1060,8 +1058,9 @@ public class MaterialCalendarView extends ViewGroup {
             final int height = child.getMeasuredHeight();
 
             int delta = (parentWidth - width) / 2;
+            int childLeft = parentLeft + delta;
 
-            child.layout(parentLeft + delta, childTop, parentLeft + width, childTop + height);
+            child.layout(childLeft, childTop, childLeft + width, childTop + height);
 
             childTop += height;
         }

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthPagerAdapter.java
@@ -1,0 +1,302 @@
+package com.prolificinteractive.materialcalendarview;
+
+import android.support.annotation.Nullable;
+import android.support.v4.view.PagerAdapter;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.prolificinteractive.materialcalendarview.format.DayFormatter;
+import com.prolificinteractive.materialcalendarview.format.WeekDayFormatter;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Pager adapter backing the calendar view
+ */
+class MonthPagerAdapter extends PagerAdapter {
+
+    private final LinkedList<MonthView> currentViews;
+    private final ArrayList<CalendarDay> months;
+
+    private MonthView.Callbacks callbacks = null;
+    private Integer color = null;
+    private Integer dateTextAppearance = null;
+    private Integer weekDayTextAppearance = null;
+    private Boolean showOtherDates = null;
+    private CalendarDay minDate = null;
+    private CalendarDay maxDate = null;
+    private CalendarDay selectedDate = null;
+    private WeekDayFormatter weekDayFormatter = WeekDayFormatter.DEFAULT;
+    private DayFormatter dayFormatter = DayFormatter.DEFAULT;
+    private List<DayViewDecorator> decorators = new ArrayList<>();
+    private List<DecoratorResult> decoratorResults = null;
+    private int firstDayOfTheWeek = Calendar.SUNDAY;
+
+
+    MonthPagerAdapter() {
+        currentViews = new LinkedList<>();
+        months = new ArrayList<>();
+        setRangeDates(null, null);
+    }
+
+
+    public void setDecorators(List<DayViewDecorator> decorators) {
+        this.decorators = decorators;
+        invalidateDecorators();
+    }
+
+    public void invalidateDecorators() {
+        decoratorResults = new ArrayList<>();
+        for (DayViewDecorator decorator : decorators) {
+            DayViewFacade facade = new DayViewFacade();
+            decorator.decorate(facade);
+            if (facade.isDecorated()) {
+                decoratorResults.add(new DecoratorResult(decorator, facade));
+            }
+        }
+        for (MonthView monthView : currentViews) {
+            monthView.setDayViewDecorators(decoratorResults);
+        }
+    }
+
+    @Override
+    public int getCount() {
+        return months.size();
+    }
+
+    public int getIndexForDay(CalendarDay day) {
+        if (day == null) {
+            return getCount() / 2;
+        }
+        if (minDate != null && day.isBefore(minDate)) {
+            return 0;
+        }
+        if (maxDate != null && day.isAfter(maxDate)) {
+            return getCount() - 1;
+        }
+        for (int i = 0; i < months.size(); i++) {
+            CalendarDay month = months.get(i);
+            if (day.getYear() == month.getYear() && day.getMonth() == month.getMonth()) {
+                return i;
+            }
+        }
+        return getCount() / 2;
+    }
+
+    @Override
+    public int getItemPosition(Object object) {
+        if (!(object instanceof MonthView)) {
+            return POSITION_NONE;
+        }
+        MonthView monthView = (MonthView) object;
+        CalendarDay month = monthView.getMonth();
+        if (month == null) {
+            return POSITION_NONE;
+        }
+        int index = months.indexOf(month);
+        if (index < 0) {
+            return POSITION_NONE;
+        }
+        return index;
+    }
+
+    @Override
+    public Object instantiateItem(ViewGroup container, int position) {
+        CalendarDay month = months.get(position);
+        MonthView monthView = new MonthView(container.getContext(), month, firstDayOfTheWeek);
+
+        monthView.setWeekDayFormatter(weekDayFormatter);
+        monthView.setDayFormatter(dayFormatter);
+        monthView.setCallbacks(callbacks);
+        if (color != null) {
+            monthView.setSelectionColor(color);
+        }
+        if (dateTextAppearance != null) {
+            monthView.setDateTextAppearance(dateTextAppearance);
+        }
+        if (weekDayTextAppearance != null) {
+            monthView.setWeekDayTextAppearance(weekDayTextAppearance);
+        }
+        if (showOtherDates != null) {
+            monthView.setShowOtherDates(showOtherDates);
+        }
+        monthView.setMinimumDate(minDate);
+        monthView.setMaximumDate(maxDate);
+        monthView.setSelectedDate(selectedDate);
+
+        container.addView(monthView);
+        currentViews.add(monthView);
+
+        monthView.setDayViewDecorators(decoratorResults);
+
+        return monthView;
+    }
+
+    public void setFirstDayOfWeek(int day) {
+        firstDayOfTheWeek = day;
+        for (MonthView monthView : currentViews) {
+            monthView.setFirstDayOfWeek(firstDayOfTheWeek);
+        }
+    }
+
+    @Override
+    public void destroyItem(ViewGroup container, int position, Object object) {
+        MonthView monthView = (MonthView) object;
+        currentViews.remove(monthView);
+        container.removeView(monthView);
+    }
+
+    @Override
+    public boolean isViewFromObject(View view, Object object) {
+        return view == object;
+    }
+
+    public void setCallbacks(MonthView.Callbacks callbacks) {
+        this.callbacks = callbacks;
+        for (MonthView monthView : currentViews) {
+            monthView.setCallbacks(callbacks);
+        }
+    }
+
+    public void setSelectionColor(int color) {
+        this.color = color;
+        for (MonthView monthView : currentViews) {
+            monthView.setSelectionColor(color);
+        }
+    }
+
+    public void setDateTextAppearance(int taId) {
+        if (taId == 0) {
+            return;
+        }
+        this.dateTextAppearance = taId;
+        for (MonthView monthView : currentViews) {
+            monthView.setDateTextAppearance(taId);
+        }
+    }
+
+    public void setShowOtherDates(boolean show) {
+        this.showOtherDates = show;
+        for (MonthView monthView : currentViews) {
+            monthView.setShowOtherDates(show);
+        }
+    }
+
+    public void setWeekDayFormatter(WeekDayFormatter formatter) {
+        this.weekDayFormatter = formatter;
+        for (MonthView monthView : currentViews) {
+            monthView.setWeekDayFormatter(formatter);
+        }
+    }
+
+    public void setDayFormatter(DayFormatter formatter) {
+        this.dayFormatter = formatter;
+        for (MonthView monthView : currentViews) {
+            monthView.setDayFormatter(formatter);
+        }
+    }
+
+    public boolean getShowOtherDates() {
+        return showOtherDates;
+    }
+
+    public void setWeekDayTextAppearance(int taId) {
+        if (taId == 0) {
+            return;
+        }
+        this.weekDayTextAppearance = taId;
+        for (MonthView monthView : currentViews) {
+            monthView.setWeekDayTextAppearance(taId);
+        }
+    }
+
+    public void setRangeDates(CalendarDay min, CalendarDay max) {
+        this.minDate = min;
+        this.maxDate = max;
+        for (MonthView monthView : currentViews) {
+            monthView.setMinimumDate(min);
+            monthView.setMaximumDate(max);
+        }
+
+        if (min == null) {
+            Calendar worker = CalendarUtils.getInstance();
+            worker.add(Calendar.YEAR, -200);
+            min = CalendarDay.from(worker);
+        }
+
+        if (max == null) {
+            Calendar worker = CalendarUtils.getInstance();
+            worker.add(Calendar.YEAR, 200);
+            max = CalendarDay.from(worker);
+        }
+
+        months.clear();
+
+        Calendar worker = CalendarUtils.getInstance();
+        min.copyToMonthOnly(worker);
+        CalendarDay workingMonth = CalendarDay.from(worker);
+        while (!max.isBefore(workingMonth)) {
+            months.add(CalendarDay.from(worker));
+            worker.add(Calendar.MONTH, 1);
+            worker.set(Calendar.DAY_OF_MONTH, 1);
+            workingMonth = CalendarDay.from(worker);
+        }
+
+        CalendarDay prevDate = selectedDate;
+        notifyDataSetChanged();
+        setSelectedDate(prevDate);
+        if (prevDate != null) {
+            if (!prevDate.equals(selectedDate)) {
+                callbacks.onDateChanged(selectedDate);
+            }
+        }
+    }
+
+    public void setSelectedDate(@Nullable CalendarDay date) {
+        CalendarDay prevDate = selectedDate;
+        this.selectedDate = getValidSelectedDate(date);
+        for (MonthView monthView : currentViews) {
+            monthView.setSelectedDate(selectedDate);
+        }
+
+        if (date == null && prevDate != null) {
+            callbacks.onDateChanged(null);
+        }
+    }
+
+    private CalendarDay getValidSelectedDate(CalendarDay date) {
+        if (date == null) {
+            return null;
+        }
+        if (minDate != null && minDate.isAfter(date)) {
+            return minDate;
+        }
+        if (maxDate != null && maxDate.isBefore(date)) {
+            return maxDate;
+        }
+        return date;
+    }
+
+    public CalendarDay getItem(int position) {
+        return months.get(position);
+    }
+
+    public CalendarDay getSelectedDate() {
+        return selectedDate;
+    }
+
+    protected int getDateTextAppearance() {
+        return dateTextAppearance == null ? 0 : dateTextAppearance;
+    }
+
+    protected int getWeekDayTextAppearance() {
+        return weekDayTextAppearance == null ? 0 : weekDayTextAppearance;
+    }
+
+    public int getFirstDayOfWeek() {
+        return firstDayOfTheWeek;
+    }
+}

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthPagerAdapter.java
@@ -107,6 +107,7 @@ class MonthPagerAdapter extends PagerAdapter {
     public Object instantiateItem(ViewGroup container, int position) {
         CalendarDay month = months.get(position);
         MonthView monthView = new MonthView(container.getContext(), month, firstDayOfTheWeek);
+        monthView.setAlpha(0);
 
         monthView.setWeekDayFormatter(weekDayFormatter);
         monthView.setDayFormatter(dayFormatter);

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthView.java
@@ -2,8 +2,12 @@ package com.prolificinteractive.materialcalendarview;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.util.AttributeSet;
 import android.view.View;
-import android.widget.LinearLayout;
+import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
 
 import com.prolificinteractive.materialcalendarview.format.DayFormatter;
 import com.prolificinteractive.materialcalendarview.format.WeekDayFormatter;
@@ -20,7 +24,7 @@ import static java.util.Calendar.DAY_OF_WEEK;
  * seven {@linkplain WeekDayView}s.
  */
 @SuppressLint("ViewConstructor")
-class MonthView extends LinearLayout implements View.OnClickListener {
+class MonthView extends ViewGroup implements View.OnClickListener {
 
     protected static final int DEFAULT_DAYS_IN_WEEK = 7;
     protected static final int DEFAULT_MAX_WEEKS = 6;
@@ -55,31 +59,27 @@ class MonthView extends LinearLayout implements View.OnClickListener {
         this.month = month;
         this.firstDayOfWeek = firstDayOfWeek;
 
-        setOrientation(VERTICAL);
-
         setClipChildren(false);
         setClipToPadding(false);
 
         Calendar calendar = resetAndGetWorkingCalendar();
 
-        LinearLayout row = makeRow(this);
         for (int i = 0; i < DEFAULT_DAYS_IN_WEEK; i++) {
             WeekDayView weekDayView = new WeekDayView(context, CalendarUtils.getDayOfWeek(calendar));
             weekDayViews.add(weekDayView);
-            row.addView(weekDayView, new LayoutParams(0, LayoutParams.MATCH_PARENT, 1f));
+            addView(weekDayView);
             calendar.add(DATE, 1);
         }
 
         calendar = resetAndGetWorkingCalendar();
 
         for(int r = 0; r < DEFAULT_MAX_WEEKS; r++) {
-            row = makeRow(this);
             for(int i = 0; i < DEFAULT_DAYS_IN_WEEK; i++) {
                 CalendarDay day = CalendarDay.from(calendar);
                 DayView dayView = new DayView(context, day);
                 dayView.setOnClickListener(this);
                 monthDayViews.add(dayView);
-                row.addView(dayView, new LayoutParams(0, LayoutParams.MATCH_PARENT, 1f));
+                addView(dayView, new LayoutParams());
 
                 calendar.add(DATE, 1);
             }
@@ -95,13 +95,6 @@ class MonthView extends LinearLayout implements View.OnClickListener {
             this.decoratorResults.addAll(results);
         }
         invalidateDecorators();
-    }
-
-    private static LinearLayout makeRow(LinearLayout parent) {
-        LinearLayout row = new LinearLayout(parent.getContext());
-        row.setOrientation(HORIZONTAL);
-        parent.addView(row, new LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f));
-        return row;
     }
 
     public void setWeekDayTextAppearance(int taId) {
@@ -241,6 +234,141 @@ class MonthView extends LinearLayout implements View.OnClickListener {
             if(callbacks != null) {
                 callbacks.onDateChanged(dayView.getDate());
             }
+        }
+    }
+
+    /*
+     * Custom ViewGroup Code
+     */
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected LayoutParams generateDefaultLayoutParams() {
+        return new LayoutParams();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
+        final int specWidthSize = MeasureSpec.getSize(widthMeasureSpec);
+        final int specWidthMode = MeasureSpec.getMode(widthMeasureSpec);
+        final int specHeightSize = MeasureSpec.getSize(heightMeasureSpec);
+        final int specHeightMode = MeasureSpec.getMode(heightMeasureSpec);
+
+        //We expect to be somewhere inside a MaterialCalendarView, which should measure EXACTLY
+        if(specHeightMode == MeasureSpec.UNSPECIFIED || specWidthMode == MeasureSpec.UNSPECIFIED) {
+            throw new IllegalStateException("MonthView should never be left to decide it's size");
+        }
+
+        //The spec width should be a correct multiple
+        final int measureTileSize = specWidthSize / DEFAULT_DAYS_IN_WEEK;
+
+        //Just use the spec sizes
+        setMeasuredDimension(specWidthSize, specHeightSize);
+
+        int count = getChildCount();
+        for (int i = 0; i < count; i++) {
+            final View child = getChildAt(i);
+
+            int childWidthMeasureSpec = MeasureSpec.makeMeasureSpec(
+                    measureTileSize,
+                    MeasureSpec.EXACTLY
+            );
+
+            int childHeightMeasureSpec = MeasureSpec.makeMeasureSpec(
+                    measureTileSize,
+                    MeasureSpec.EXACTLY
+            );
+
+            child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        final int count = getChildCount();
+
+        final int parentLeft = 0;
+        final int parentTop = 0;
+
+        int childTop = parentTop;
+        int childLeft = parentLeft;
+
+        for (int i = 0; i < count; i++) {
+            final View child = getChildAt(i);
+
+            final int width = child.getMeasuredWidth();
+            final int height = child.getMeasuredHeight();
+
+            child.layout(childLeft, childTop, childLeft + width, childTop + height);
+
+            childLeft += width;
+
+            //We should warp every so many children
+            if(i % DEFAULT_DAYS_IN_WEEK == (DEFAULT_DAYS_IN_WEEK - 1)) {
+                childLeft = parentLeft;
+                childTop += height;
+            }
+
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LayoutParams generateLayoutParams(AttributeSet attrs) {
+        return new LayoutParams();
+    }
+
+    @Override
+    public boolean shouldDelayChildPressedState() {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean checkLayoutParams(ViewGroup.LayoutParams p) {
+        return p instanceof LayoutParams;
+    }
+
+    @Override
+    protected ViewGroup.LayoutParams generateLayoutParams(ViewGroup.LayoutParams p) {
+        return new LayoutParams();
+    }
+
+
+    @Override
+    public void onInitializeAccessibilityEvent(@NonNull AccessibilityEvent event) {
+        super.onInitializeAccessibilityEvent(event);
+        event.setClassName(MonthView.class.getName());
+    }
+
+    @Override
+    public void onInitializeAccessibilityNodeInfo(@NonNull AccessibilityNodeInfo info) {
+        super.onInitializeAccessibilityNodeInfo(info);
+        info.setClassName(MonthView.class.getName());
+    }
+
+    /**
+     * Simple layout params class for MonthView, since every child is the same size
+     */
+    private static class LayoutParams extends MarginLayoutParams {
+
+        /**
+         * {@inheritDoc}
+         */
+        public LayoutParams() {
+            super(WRAP_CONTENT, WRAP_CONTENT);
         }
     }
 }


### PR DESCRIPTION
This will be a breaking change. the way the view reacts to layout parameters is improved. The functionality is similar to how `adjustViewBounds` works with ImageView, where the view will try and take up as much space as necessary, but we base it on tile size instead of an aspect ratio. The exception being that if a `tileSize` is set, that will override everything and set the view to that size.

This also better, but still incomplete, support for editing mode. You can now see a preview of a month instead of just whitespace.

And finally, `MonthPagerAdapter` was moved to it's own file, since `MaterialCalendarView` was getting a little big.

Issues this should close: #84, #44, #87, #46