### PR TITLE
1.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 1.0.0 *(2015-09-30)*
 * New: Added ability to select multiple dates or disable selection completely
 * Change: `OnDateChangedListener` has become `OnDateSelectedListener` with different functionality
 * Change: `showOtherDates` is now a integer flag for finer control over which days are shown
+* Change: `CalendarDay.toString()` no longer adds one to the month
 
 Version 0.8.1 *(2015-08-28)*
 ----------------------------

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarDay.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarDay.java
@@ -7,7 +7,6 @@ import android.support.annotation.Nullable;
 
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Locale;
 
 /**
  * An imputable representation of a day on a calendar
@@ -273,7 +272,7 @@ public final class CalendarDay implements Parcelable {
 
     @Override
     public String toString() {
-        return String.format(Locale.US, "CalendarDay{%d-%d-%d}", year, month + 1, day);
+        return "CalendarDay{" + year + "-" + month + "-" + day + "}";
     }
 
     /*


### PR DESCRIPTION
This PR as a review period before the 1.0.0 release. If no major issues are found, this will be released on September 30th (probably around 10 am PDT).

You can test it out by use 
```
compile 'com.prolificinteractive:material-calendarview:1.0.0-beta1'
```

Please try it out and report back issues here. 

Changes in this release:
* New: Added ability to select multiple dates or disable selection completely
* Change: `OnDateChangedListener` has become `OnDateSelectedListener` with different functionality
* Change: `showOtherDates` is now a integer flag for finer control over which days are shown