### PR TITLE
Making edges of the calendar view scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 1.2.0 *(FUTURE)*
+----------------------------
+
+* Fix: Disable paging also disables arrows
+* New: Dynamic Height, the calendar can now resize it's height based on the currently visible month
+
 Version 1.1.0 *(2015-10-19)*
 ----------------------------
 

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -17,6 +17,7 @@ import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.accessibility.AccessibilityEvent;
@@ -471,6 +472,17 @@ public class MaterialCalendarView extends ViewGroup {
      */
     private boolean canGoForward() {
         return pager.getCurrentItem() < (adapter.getCount() - 1);
+    }
+
+    /**
+     * Pass all touch events to the pager so scrolling works on the edges of the calendar view.
+     * 
+     * @param event
+     * @return
+     */
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        return pager.dispatchTouchEvent(event);
     }
 
     /**

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -470,7 +470,7 @@ public class MaterialCalendarView extends ViewGroup {
      * @return true if there is a future month that can be shown
      */
     private boolean canGoForward() {
-        return pager.isPagingEnabled() && pager.getCurrentItem() < (adapter.getCount() - 1);
+        return pager.getCurrentItem() < (adapter.getCount() - 1);
     }
 
     /**
@@ -479,7 +479,7 @@ public class MaterialCalendarView extends ViewGroup {
      * @return true if there is a previous month that can be shown
      */
     private boolean canGoBack() {
-        return pager.isPagingEnabled() && pager.getCurrentItem() > 0;
+        return pager.getCurrentItem() > 0;
     }
 
     /**

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthPager.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthPager.java
@@ -15,13 +15,6 @@ class MonthPager extends BetterViewPager {
         super(context);
     }
 
-    @Override
-    public void scrollTo(int x, int y) {
-        if (pagingEnabled) {
-            super.scrollTo(x, y);
-        }
-    }
-
     /**
      * enable disable viewpager scroll
      *
@@ -44,7 +37,7 @@ class MonthPager extends BetterViewPager {
     }
 
     @Override
-    public void setPageTransformer(boolean reverseDrawingOrder, PageTransformer transformer) {
-        super.setPageTransformer(reverseDrawingOrder, transformer);
+    public boolean onTouchEvent(MotionEvent ev) {
+        return pagingEnabled && super.onTouchEvent(ev);
     }
 }


### PR DESCRIPTION
This change enables scrolling for the entire width of the material calendar view. 

Primarily useful for when the tile size is small and the visible calendar view is smaller and there is what looks like padding on the edges. Makes scrolling very natural from the edges of the screen when there is no padding on the right and left of the calendar view. 