### PR TITLE
Fixed CalendarPager scrolling in nested ViewPager

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPager.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPager.java
@@ -40,4 +40,23 @@ class CalendarPager extends BetterViewPager {
     public boolean onTouchEvent(MotionEvent ev) {
         return pagingEnabled && super.onTouchEvent(ev);
     }
+
+    @Override
+    public boolean canScrollVertically(int direction) {
+        /**
+         * disables scrolling vertically when paging disabled, fixes scrolling
+         * for nested {@link android.support.v4.view.ViewPager}
+         */
+        return pagingEnabled && super.canScrollVertically(direction);
+    }
+
+    @Override
+    public boolean canScrollHorizontally(int direction) {
+        /**
+         * disables scrolling horizontally when paging disabled, fixes scrolling
+         * for nested {@link android.support.v4.view.ViewPager}
+         */
+        return pagingEnabled && super.canScrollHorizontally(direction);
+    }
+
 }


### PR DESCRIPTION
This should fix scrolling when nesting the calendar inside a ViewPager. The commit prevents the CalendarPager from consuming the parent scrolling touch event when paging is set to false. Should also fix #111.