### PR TITLE
Selection from to

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -1530,24 +1530,25 @@ public class MaterialCalendarView extends ViewGroup {
         return pager.isPagingEnabled();
     }
 
+    // Manages the selection option SELECTION_MODE_FROM_TO
     private void selectionFromTo(CalendarDay date, boolean selected) {
         MaterialCalendarView calendario= this;
         CalendarDay fechaPulsada= date;
         List<CalendarDay> diasSeleccionados= this.getSelectedDates();
 
-        // Un complejo IF para analizar. Entra si:
-        // - Si no tenemos nada seleccionado
-        // - Si tenemos un rango seleccionado y queremos declarar otro
-        // En cualquier caso, se trata de marcar el inicio del periodo
+        // Let's analyze that IF sentence. It executes if:
+        // - If there's nothing selected
+        // - If there's a period selected and we want to declare other
+        // Anyway, this selects the begin of the period
         if (diasSeleccionados.isEmpty() || diasSeleccionados.size() > 1) {
             calendario.setSelectedDate(fechaPulsada);
         }
         else {
-            // Es el único elemento que hay y por tanto queremos desmarcarlo
+            // If only it is selected the day taped and we want to deselect it.
             if (!selected) {
                 calendario.clearSelection();
             }
-            // Hay un elemento marcado y seleccionamos el final de periodo
+            // There's one day selected and we tap the final day from the period
             else {
                 CalendarDay diaInicial= diasSeleccionados.get(0);
 
@@ -1557,13 +1558,14 @@ public class MaterialCalendarView extends ViewGroup {
         }
     }
 
+    // This method selects all days between the passed days
     private void desdeHasta(CalendarDay diaInicial, CalendarDay diaFinal) {
         MaterialCalendarView calendario= this;
 
-        // Por si acaso, limpiamos cualquier selección
+        // For security reasons, we clear all selections
         calendario.clearSelection();
 
-        // Recorrido al derecho
+        // The standard way
         if (diaInicial.isBefore(diaFinal)) {
             for (CalendarDay diaAseleccionar= diaInicial;
                  diaAseleccionar.isInRange(diaInicial, diaFinal);
@@ -1571,7 +1573,7 @@ public class MaterialCalendarView extends ViewGroup {
                 calendario.setDateSelected(diaAseleccionar, true);
             }
         }
-        // Recorrido a la inversa
+        // The reverse way
         else {
             for (CalendarDay diaAseleccionar= diaInicial;
                  diaAseleccionar.isInRange(diaFinal, diaInicial);
@@ -1584,7 +1586,7 @@ public class MaterialCalendarView extends ViewGroup {
     private CalendarDay nextDay(CalendarDay dia) {
         Date dt= dia.getDate();
 
-        // Truco del almendruco gracias a:
+        // The trick was taken from:
         // http://stackoverflow.com/questions/1005523/how-to-add-one-day-to-a-date
         Calendar c = Calendar.getInstance();
         c.setTime(dt);
@@ -1597,7 +1599,7 @@ public class MaterialCalendarView extends ViewGroup {
     private CalendarDay pastDay(CalendarDay dia) {
         Date dt= dia.getDate();
 
-        // Truco del almendruco gracias a:
+        // The trick was taken from:
         // http://stackoverflow.com/questions/1005523/how-to-add-one-day-to-a-date
         Calendar c = Calendar.getInstance();
         c.setTime(dt);

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -14,7 +14,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.util.SparseArray;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -1561,18 +1560,14 @@ public class MaterialCalendarView extends ViewGroup {
     private void desdeHasta(CalendarDay diaInicial, CalendarDay diaFinal) {
         MaterialCalendarView calendario= this;
 
-        Log.e("Mostramos dia inicial", diaInicial.toString());
-        Log.e("Mostramos dia final", diaFinal.toString());
         // Por si acaso, limpiamos cualquier selección
         calendario.clearSelection();
 
         // Recorrido al derecho
         if (diaInicial.isBefore(diaFinal)) {
-            Log.e("Mostramos dia final", diaFinal.toString());
             for (CalendarDay diaAseleccionar= diaInicial;
                  diaAseleccionar.isInRange(diaInicial, diaFinal);
                  diaAseleccionar= nextDay(diaAseleccionar)) {
-                Log.e("Dia procesado", diaAseleccionar.toString());
                 calendario.setDateSelected(diaAseleccionar, true);
             }
         }
@@ -1581,7 +1576,6 @@ public class MaterialCalendarView extends ViewGroup {
             for (CalendarDay diaAseleccionar= diaInicial;
                  diaAseleccionar.isInRange(diaFinal, diaInicial);
                  diaAseleccionar= pastDay(diaAseleccionar)) {
-                Log.e("Dia procesado", diaAseleccionar.toString());
                 calendario.setDateSelected(diaAseleccionar, true);
             }
         }

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -1536,36 +1536,19 @@ public class MaterialCalendarView extends ViewGroup {
         CalendarDay fechaPulsada= date;
         List<CalendarDay> diasSeleccionados= this.getSelectedDates();
 
-        // El elemento sobre el que pulsamos no está seleccionado
-        if (selected) {
-            // Un complejo IF para analizar. Entra si:
-            // - Si no tenemos nada seleccionado
-            // - Si tenemos un rango seleccionado y queremos declarar otro
-            if (diasSeleccionados.isEmpty() || diasSeleccionados.size() > 1) {
-                calendario.setSelectedDate(fechaPulsada);
-            }
-            // Si ya hay más de un día seleccionado
-            else {
-                CalendarDay diaInicial= diasSeleccionados.get(0);
-
-                desdeHasta(diaInicial, fechaPulsada);
-            }
-            // Y qué pasa si tenemos ya un rango seleccionado?
+        // Un complejo IF para analizar. Entra si:
+        // - Si no tenemos nada seleccionado
+        // - Si tenemos un rango seleccionado y queremos declarar otro
+        // En cualquier caso, se trata de marcar el inicio del periodo
+        if (diasSeleccionados.isEmpty() || diasSeleccionados.size() > 1) {
+            calendario.setSelectedDate(fechaPulsada);
         }
-        // El elemento sobre el que pulsamos ya está seleccionado
         else {
-            // El elemento sobre el que pulsamos es el único
-            if (diasSeleccionados.size() == 1) {
+            // Es el único elemento que hay y por tanto queremos desmarcarlo
+            if (!selected) {
                 calendario.clearSelection();
             }
-            // El elemento sobre el que pulsamos es el último
-            else if (diasSeleccionados.get(diasSeleccionados.size()-1).equals(fechaPulsada)) {
-                calendario.setSelectedDate(fechaPulsada);
-            }
-            // Hay que deshacer un rango seleccionado
-            // La lógica es la siguiente:
-            // - Seleccionar unicamente el día inicial del periodo seleccionado
-            // - Pasar a seleccionar un nuevo periodo
+            // Hay un elemento marcado y seleccionamos el final de periodo
             else {
                 CalendarDay diaInicial= diasSeleccionados.get(0);
 

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -14,6 +14,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.SparseArray;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -1537,8 +1538,10 @@ public class MaterialCalendarView extends ViewGroup {
 
         // El elemento sobre el que pulsamos no está seleccionado
         if (selected) {
-            // Si es el primer elemento a seleccionar
-            if (diasSeleccionados.isEmpty()) {
+            // Un complejo IF para analizar. Entra si:
+            // - Si no tenemos nada seleccionado
+            // - Si tenemos un rango seleccionado y queremos declarar otro
+            if (diasSeleccionados.isEmpty() || diasSeleccionados.size() > 1) {
                 calendario.setSelectedDate(fechaPulsada);
             }
             // Si ya hay más de un día seleccionado
@@ -1554,6 +1557,10 @@ public class MaterialCalendarView extends ViewGroup {
             // El elemento sobre el que pulsamos es el único
             if (diasSeleccionados.size() == 1) {
                 calendario.clearSelection();
+            }
+            // El elemento sobre el que pulsamos es el último
+            else if (diasSeleccionados.get(diasSeleccionados.size()-1).equals(fechaPulsada)) {
+                calendario.setSelectedDate(fechaPulsada);
             }
             // Hay que deshacer un rango seleccionado
             // La lógica es la siguiente:
@@ -1571,14 +1578,18 @@ public class MaterialCalendarView extends ViewGroup {
     private void desdeHasta(CalendarDay diaInicial, CalendarDay diaFinal) {
         MaterialCalendarView calendario= this;
 
+        Log.e("Mostramos dia inicial", diaInicial.toString());
+        Log.e("Mostramos dia final", diaFinal.toString());
         // Por si acaso, limpiamos cualquier selección
         calendario.clearSelection();
 
         // Recorrido al derecho
         if (diaInicial.isBefore(diaFinal)) {
+            Log.e("Mostramos dia final", diaFinal.toString());
             for (CalendarDay diaAseleccionar= diaInicial;
                  diaAseleccionar.isInRange(diaInicial, diaFinal);
                  diaAseleccionar= nextDay(diaAseleccionar)) {
+                Log.e("Dia procesado", diaAseleccionar.toString());
                 calendario.setDateSelected(diaAseleccionar, true);
             }
         }
@@ -1587,6 +1598,7 @@ public class MaterialCalendarView extends ViewGroup {
             for (CalendarDay diaAseleccionar= diaInicial;
                  diaAseleccionar.isInRange(diaFinal, diaInicial);
                  diaAseleccionar= pastDay(diaAseleccionar)) {
+                Log.e("Dia procesado", diaAseleccionar.toString());
                 calendario.setDateSelected(diaAseleccionar, true);
             }
         }


### PR DESCRIPTION
Material Calendar View is perfect to my application due to the high customization way for day decoration.
But, my client was very specific about the way that the selection must work. So I created this mode: **SELECTION_MODE_FROM_TO**.

It's a new multiple selection mode that allow the user selects a period of days just tapping the first and the last day. It works on reverse seleccion: tapping the last day and then the first.
I think that's very useful and more intuitive than the standar multiple selection. Coders can also allow to change to the SELECTION_MODE_MULTIPLE to deselect specific days.