### PR TITLE
Feature - Add calendarMode attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 1.3.0 *(TBD)*
 * New: MCV `goToNext` and `goToPrevious` API to programmatically trigger paging
 * New: Allow users to click on dates outside of current month with `setAllowClickDaysOutsideCurrentMonth`
 * New: Set tile width/height separately rather than single tile size
+* New: Attributes: mcv_tileWidth, mcv_tileHeight, mcv_calendarMode
 * Change: `getTileSize` is deprecated, use `getTileWidth` and `getTileHeight`. `setTileSize` still works as a convenience method to set width and height at the same time.
 * Fix: Fix - issue with arrow not enabled when setting maxDate
 * Fix: TalkBack content descriptions for pager view, forward/back arrows, and ability to set them manually

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
@@ -25,7 +25,7 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
 
     protected static final int DEFAULT_DAYS_IN_WEEK = 7;
     protected static final int DEFAULT_MAX_WEEKS = 6;
-    protected static final int DEFAULT_MAX_ROWS = DEFAULT_MAX_WEEKS + 1; // include days header
+    protected static final int DAY_NAMES_ROW = 1;
     private static final Calendar tempWorkingCalendar = CalendarUtils.getInstance();
     private final ArrayList<WeekDayView> weekDayViews = new ArrayList<>();
     private final ArrayList<DecoratorResult> decoratorResults = new ArrayList<>();
@@ -243,7 +243,7 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
 
         //The spec width should be a correct multiple
         final int measureTileWidth = specWidthSize / DEFAULT_DAYS_IN_WEEK;
-        final int measureTileHeight = specHeightSize / DEFAULT_MAX_ROWS;
+        final int measureTileHeight = specHeightSize / getRows();
 
         //Just use the spec sizes
         setMeasuredDimension(specWidthSize, specHeightSize);
@@ -266,6 +266,12 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
             child.measure(childWidthMeasureSpec, childHeightMeasureSpec);
         }
     }
+
+    /**
+     * Return the number of rows to display per page
+     * @return
+     */
+    protected abstract int getRows();
 
     /**
      * {@inheritDoc}

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MonthView.java
@@ -34,4 +34,9 @@ class MonthView extends CalendarPagerView {
     protected boolean isDayEnabled(CalendarDay day) {
         return day.getMonth() == getFirstViewDay().getMonth();
     }
+
+    @Override
+    protected int getRows() {
+        return DEFAULT_MAX_WEEKS + DAY_NAMES_ROW;
+    }
 }

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/WeekView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/WeekView.java
@@ -30,4 +30,9 @@ public class WeekView extends CalendarPagerView {
     protected boolean isDayEnabled(CalendarDay day) {
         return true;
     }
+
+    @Override
+    protected int getRows() {
+        return DAY_NAMES_ROW + 1;
+    }
 }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -40,7 +40,10 @@
             <enum name="saturday" value="7" />
         </attr>
 
-
+        <attr name="mcv_calendarMode" format="enum">
+            <enum name="month" value="0" />
+            <enum name="week" value="1" />
+        </attr>
     </declare-styleable>
 
 </resources>

--- a/sample/src/main/res/layout/activity_customization.xml
+++ b/sample/src/main/res/layout/activity_customization.xml
@@ -27,6 +27,7 @@
         app:mcv_monthLabels="@array/custom_months"
         app:mcv_tileSize="36dp"
         app:mcv_firstDayOfWeek="thursday"
+        app:mcv_calendarMode="week"
         />
 
 </LinearLayout>


### PR DESCRIPTION
#288 #285
- Week mode can now be set in xml as `app:mcv_calendarMode="week"`. Default is still months.
- Fixed some erroneous row calculations from prior assumptions.
- XML Sample activity demonstrates this usage now, setting calendarMode to week

@quentin41500 