### PR TITLE
Fix class cast exception in CPA

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
@@ -122,9 +122,9 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
         if (!(isInstanceOfView(object))) {
             return POSITION_NONE;
         }
-        MonthView monthView = (MonthView) object;
-        CalendarDay month = monthView.getMonth();
-        if (month == null) {
+        CalendarPagerView pagerView = (CalendarPagerView) object;
+        CalendarDay firstViewDay = pagerView.getFirstViewDay();
+        if (firstViewDay == null) {
             return POSITION_NONE;
         }
         int index = indexOf((V) object);


### PR DESCRIPTION
#285

CPA had old logic for getItemPosition that was for Months only. 

Known issue: getItemPosition seems to be giving wrong position for Week mode

@quentin41500 