### PR TITLE
Conditionally fix max date support for weeks

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
@@ -83,12 +83,14 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
         newAdapter.color = color;
         newAdapter.dateTextAppearance = dateTextAppearance;
         newAdapter.weekDayTextAppearance = weekDayTextAppearance;
-        newAdapter.dayFormatter = dayFormatter;
-        newAdapter.decorators = decorators;
         newAdapter.showOtherDates = showOtherDates;
         newAdapter.minDate = minDate;
         newAdapter.maxDate = maxDate;
         newAdapter.selectedDates = selectedDates;
+        newAdapter.weekDayFormatter = weekDayFormatter;
+        newAdapter.dayFormatter = dayFormatter;
+        newAdapter.decorators = decorators;
+        newAdapter.decoratorResults = decoratorResults;
         newAdapter.selectionEnabled = selectionEnabled;
         return newAdapter;
     }

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -498,6 +498,7 @@ public class MaterialCalendarView extends ViewGroup {
             adapter = adapter.migrateStateAndReturn(newAdapter);
         }
         pager.setAdapter(adapter);
+        setRangeDates(minDate, maxDate);
         calendarMode = mode;
 
         // Reset height params after mode change
@@ -1249,7 +1250,7 @@ public class MaterialCalendarView extends ViewGroup {
 
     /**
      * Sets the first day of the week.
-     * <p>
+     * <p/>
      * Uses the java.util.Calendar day constants.
      *
      * @param day The first day of the week as a java.util.Calendar day constant.
@@ -1277,6 +1278,7 @@ public class MaterialCalendarView extends ViewGroup {
             adapter = adapter.migrateStateAndReturn(newAdapter);
         }
         pager.setAdapter(adapter);
+        setRangeDates(minDate, maxDate);
 
         setCurrentDate(
                 selectionMode == SELECTION_MODE_SINGLE && !adapter.getSelectedDates().isEmpty()
@@ -1296,7 +1298,7 @@ public class MaterialCalendarView extends ViewGroup {
     /**
      * By default, the calendar will take up all the space needed to show any month (6 rows).
      * By enabling dynamic height, the view will change height dependant on the visible month.
-     * <p>
+     * <p/>
      * This means months that only need 5 or 4 rows to show the entire month will only take up
      * that many rows, and will grow and shrink as necessary.
      *

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/WeekPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/WeekPagerAdapter.java
@@ -41,7 +41,7 @@ public class WeekPagerAdapter extends CalendarPagerAdapter<WeekView> {
 
         public Weekly(@NonNull CalendarDay min, @NonNull CalendarDay max, int firstDayOfWeek) {
             this.min = getFirstDayOfWeek(min, firstDayOfWeek);
-            this.count = weekNumberDifference(min, max);
+            this.count = weekNumberDifference(min, max) + 1;
         }
 
         @Override

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/CustomizeCodeActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/CustomizeCodeActivity.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.TypedValue;
 
+import com.prolificinteractive.materialcalendarview.CalendarDay;
+import com.prolificinteractive.materialcalendarview.CalendarMode;
 import com.prolificinteractive.materialcalendarview.MaterialCalendarView;
 import com.prolificinteractive.materialcalendarview.format.ArrayWeekDayFormatter;
 import com.prolificinteractive.materialcalendarview.format.MonthArrayTitleFormatter;
@@ -35,7 +37,15 @@ public class CustomizeCodeActivity extends AppCompatActivity {
         widget.setTitleFormatter(new MonthArrayTitleFormatter(getResources().getTextArray(R.array.custom_months)));
         widget.setWeekDayFormatter(new ArrayWeekDayFormatter(getResources().getTextArray(R.array.custom_weekdays)));
         widget.setTileSize((int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 36, getResources().getDisplayMetrics()));
-        widget.setFirstDayOfWeek(Calendar.THURSDAY);
+
+        CalendarDay today = CalendarDay.from(2016, 5, 2);
+        widget.setCurrentDate(today);
+        widget.setSelectedDate(today);
+
+        widget.setFirstDayOfWeek(Calendar.WEDNESDAY);
+        widget.setMinimumDate(CalendarDay.from(2016, 4, 3));
+        widget.setMaximumDate(CalendarDay.from(2016, 5, 12));
+        widget.setCalendarDisplayMode(CalendarMode.WEEKS);
     }
 
 }


### PR DESCRIPTION
#293

- Missing state params to be migrated as part of `migrateState` to new adapter call
- Recreate dateRanges whenever new adapter is made and state is copied (`calendarMode` and `setFirstDayOfWeek`)

This should fix for ...most cases. The example is updated to actually show a combination of first day of week + min date + max date which breaks (does not let you page to the next week, which is valid). It is not known why; probably some combination of calculating week delta in addition to the offset based on starting day.