### PR TITLE
Feature - Selection Range of date

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarUtils.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarUtils.java
@@ -51,6 +51,13 @@ public class CalendarUtils {
         calendar.set(year, month, 1);
     }
 
+    public static CalendarDay nextDay(final CalendarDay date) {
+        final Calendar c = Calendar.getInstance();
+        c.setTime(date.getDate());
+        c.add(Calendar.DATE, 1);
+        return CalendarDay.from(c.getTime());
+    }
+
     /**
      * Copy <i>only</i> date information to a new calendar.
      *

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/DynamicSettersActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/DynamicSettersActivity.java
@@ -230,7 +230,8 @@ public class DynamicSettersActivity extends AppCompatActivity {
         CharSequence[] items = {
                 "No Selection",
                 "Single Date",
-                "Multiple Dates"
+                "Multiple Dates",
+                "Range selection"
         };
         new AlertDialog.Builder(this)
                 .setTitle("Selection Mode")


### PR DESCRIPTION
This PR is taken from @damian-aragunde-udc (huge thanks to him), cleaned up and updated for being merged in the right branch. PR #262 will be closed as this one does the exact same thing. 

With this PR you can have access to a new selection mode called SELECTION_MODE_RANGE. That allows you to select two dates and all the dates that are in between instantly. You can also use the new api method `MaterialCalendarView.selectDaysInRange(firstDay, lastDay)` to select a range of dates programmatically. This mode can be tested in `DynamicSettersActivity` in the sample app.

Documentation will be done in a separate PR, if this is accepted.

Reviewer: @ekchang @Jogan @chahinem 