### PR TITLE
Add select range functionality

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/OnRangeSelectedListener.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/OnRangeSelectedListener.java
@@ -1,0 +1,20 @@
+package com.prolificinteractive.materialcalendarview;
+
+import android.support.annotation.NonNull;
+
+import java.util.List;
+
+/**
+ * The callback used to indicate a range has been selected
+ */
+public interface OnRangeSelectedListener {
+
+    /**
+     * Called when a user selects a range of days.
+     * There is no logic to prevent multiple calls for the same date and state.
+     *
+     * @param widget   the view associated with this listener
+     * @param dates     the dates in the range, in ascending order
+     */
+    void onRangeSelected(@NonNull MaterialCalendarView widget, @NonNull List<CalendarDay> dates);
+}


### PR DESCRIPTION
Fix #245 

This adds select range functionality. When two dates are selected, the callback returns a sorted (ascending) list of dates in that range. 

After that, if another date is selected, it clears the previous selection on the widget and waits for a second one for a new range select.

I tried to keep the documentation style as close to the original as possible. Please forgive any mistakes.

**Usage**

Set the new selection mode:
`mcv.setSelectionMode(MaterialCalendarView.SELECTION_MODE_RANGE);`

And the listener:
`mcv.setOnRangeSelectedListener(new OnRangeSelectedListener() {
           @Override
            public void onRangeSelected(@NonNull MaterialCalendarView widget, @NonNull List<CalendarDay> dates) {
                //  do stuff
            }
        });`

The `List<CalendarDay> dates` is the desired range. It also works with a backwards selection, but the list will always be returned sorted in ascending order.