### PR TITLE
Final - Select range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-23.0.2
+    - build-tools-23.0.3
     - android-23
     - extra-android-m2repository
     - extra-google-m2repository

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 14

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -12,7 +12,6 @@ import android.support.annotation.ArrayRes;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.util.Pair;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.util.SparseArray;
@@ -42,8 +41,6 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 /**
  * <p>
@@ -438,6 +435,8 @@ public class MaterialCalendarView extends ViewGroup {
         switch (mode) {
             case SELECTION_MODE_RANGE:
                 clearSelection();
+                break;
+            case SELECTION_MODE_MULTIPLE:
                 break;
             case SELECTION_MODE_SINGLE:
                 if (oldMode == SELECTION_MODE_MULTIPLE || oldMode == SELECTION_MODE_RANGE) {
@@ -1201,7 +1200,7 @@ public class MaterialCalendarView extends ViewGroup {
     /**
      * By default, the calendar will take up all the space needed to show any month (6 rows).
      * By enabling dynamic height, the view will change height dependant on the visible month.
-     * <p/>
+     * <p>
      * This means months that only need 5 or 4 rows to show the entire month will only take up
      * that many rows, and will grow and shrink as necessary.
      *
@@ -1326,7 +1325,7 @@ public class MaterialCalendarView extends ViewGroup {
     }
 
     /**
-     * Dispatch a range of days to a listener, if set
+     * Dispatch a range of days to a listener, if set. First day must be before last Day.
      *
      * @param firstDay first day enclosing a range
      * @param lastDay  last day enclosing a range
@@ -1335,18 +1334,11 @@ public class MaterialCalendarView extends ViewGroup {
         final OnRangeSelectedListener listener = rangeListener;
         final List<CalendarDay> days = new ArrayList<>();
 
-        final SortedSet<Date> sortedDays = new TreeSet<>();
-        sortedDays.add(firstDay.getDate());
-        sortedDays.add(lastDay.getDate());
-
-        final Date first = sortedDays.first();  //  min date
-        final Date last = sortedDays.last();  //  max date
-
         final Calendar counter = Calendar.getInstance();
-        counter.setTime(first);  //  start from the first day and increment
+        counter.setTime(firstDay.getDate());  //  start from the first day and increment
 
         final Calendar end = Calendar.getInstance();
-        end.setTime(last);  //  for comparison
+        end.setTime(lastDay.getDate());  //  for comparison
 
         while (counter.before(end) || counter.equals(end)) {
             final CalendarDay current = CalendarDay.from(counter);
@@ -1394,7 +1386,11 @@ public class MaterialCalendarView extends ViewGroup {
                     dispatchOnDateSelected(date, nowSelected);
                 } else if (adapter.getSelectedDates().size() == 2) {
                     final List<CalendarDay> dates = adapter.getSelectedDates();
-                    dispatchOnRangeSelected(dates.get(0), dates.get(1));
+                    if (dates.get(0).isAfter(dates.get(1))) {
+                        dispatchOnRangeSelected(dates.get(1), dates.get(0));
+                    } else {
+                        dispatchOnRangeSelected(dates.get(0), dates.get(1));
+                    }
                 } else {
                     adapter.setDateSelected(date, nowSelected);
                     dispatchOnDateSelected(date, nowSelected);
@@ -1419,7 +1415,11 @@ public class MaterialCalendarView extends ViewGroup {
      */
     public void selectRange(final CalendarDay firstDay, final CalendarDay lastDay) {
         clearSelection();
-        dispatchOnRangeSelected(firstDay, lastDay);
+        if (firstDay.isAfter(lastDay)) {
+            dispatchOnRangeSelected(lastDay, firstDay);
+        } else {
+            dispatchOnRangeSelected(firstDay, lastDay);
+        }
     }
 
     /**
@@ -1786,7 +1786,7 @@ public class MaterialCalendarView extends ViewGroup {
 
         /**
          * Sets the first day of the week.
-         * <p/>
+         * <p>
          * Uses the java.util.Calendar day constants.
          *
          * @param day The first day of the week as a java.util.Calendar day constant.

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -12,6 +12,7 @@ import android.support.annotation.ArrayRes;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.util.Pair;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.util.SparseArray;
@@ -41,6 +42,8 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * <p>
@@ -73,7 +76,7 @@ public class MaterialCalendarView extends ViewGroup {
      * @see #getSelectionMode()
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @IntDef({SELECTION_MODE_NONE, SELECTION_MODE_SINGLE, SELECTION_MODE_MULTIPLE})
+    @IntDef({SELECTION_MODE_NONE, SELECTION_MODE_SINGLE, SELECTION_MODE_MULTIPLE, SELECTION_MODE_RANGE})
     public @interface SelectionMode {
     }
 
@@ -94,6 +97,11 @@ public class MaterialCalendarView extends ViewGroup {
      * Selection mode which allows more than one selected date at one time.
      */
     public static final int SELECTION_MODE_MULTIPLE = 2;
+
+    /**
+     * Selection mode which allows selection of a range between two dates
+     */
+    public static final int SELECTION_MODE_RANGE = 3;
 
     /**
      * {@linkplain IntDef} annotation for showOtherDates.
@@ -204,6 +212,8 @@ public class MaterialCalendarView extends ViewGroup {
 
     private OnDateSelectedListener listener;
     private OnMonthChangedListener monthListener;
+    private OnRangeSelectedListener rangeListener;
+
 
     CharSequence calendarContentDescription;
     private int accentColor = 0;
@@ -419,6 +429,7 @@ public class MaterialCalendarView extends ViewGroup {
      * @see #SELECTION_MODE_NONE
      * @see #SELECTION_MODE_SINGLE
      * @see #SELECTION_MODE_MULTIPLE
+     * @see #SELECTION_MODE_RANGE
      */
     public void setSelectionMode(final @SelectionMode int mode) {
         final @SelectionMode int oldMode = this.selectionMode;
@@ -445,6 +456,10 @@ public class MaterialCalendarView extends ViewGroup {
                     //No selection! Clear out!
                     clearSelection();
                 }
+            }
+            break;
+            case SELECTION_MODE_RANGE: {
+                this.selectionMode = SELECTION_MODE_RANGE;
             }
             break;
         }
@@ -1088,6 +1103,7 @@ public class MaterialCalendarView extends ViewGroup {
         currentMonth = c;
         int position = adapter.getIndexForDay(c);
         pager.setCurrentItem(position, false);
+        updateUi();
     }
 
     public static class SavedState extends BaseSavedState {
@@ -1293,6 +1309,15 @@ public class MaterialCalendarView extends ViewGroup {
     }
 
     /**
+     * Sets the listener to be notified upon a range has been selected.
+     *
+     * @param listener thing to be notified
+     */
+    public void setOnRangeSelectedListener(OnRangeSelectedListener listener) {
+        this.rangeListener = listener;
+    }
+
+    /**
      * Dispatch date change events to a listener, if set
      *
      * @param day      the day that was selected
@@ -1302,6 +1327,38 @@ public class MaterialCalendarView extends ViewGroup {
         OnDateSelectedListener l = listener;
         if (l != null) {
             l.onDateSelected(MaterialCalendarView.this, day, selected);
+        }
+    }
+
+    /**
+     * Dispatch a range of days to a listener, if set
+     *
+     * @param pair      the pair of days enclosing a range
+     */
+    protected void dispatchOnRangeSelected(Pair<CalendarDay, CalendarDay> pair) {
+        OnRangeSelectedListener listener = rangeListener;
+        List<CalendarDay> days = new ArrayList<>();
+
+        SortedSet<Date> sortedDays = new TreeSet<>();
+        sortedDays.add(pair.first.getDate());
+        sortedDays.add(pair.second.getDate());
+
+        Date first = sortedDays.first();  //  min date
+        Date last = sortedDays.last();  //  max date
+
+        Calendar counter = Calendar.getInstance();
+        counter.setTime(first);  //  start from the first day and increment
+
+        Calendar end = Calendar.getInstance();
+        end.setTime(last);  //  for comparison
+
+        while (counter.before(end) || counter.equals(end)) {
+            days.add(CalendarDay.from(counter));
+            counter.add(Calendar.DATE, 1);
+        }
+
+        if (listener != null) {
+            listener.onRangeSelected(MaterialCalendarView.this, days);
         }
     }
 
@@ -1329,6 +1386,22 @@ public class MaterialCalendarView extends ViewGroup {
             case SELECTION_MODE_MULTIPLE: {
                 adapter.setDateSelected(date, nowSelected);
                 dispatchOnDateSelected(date, nowSelected);
+            }
+            break;
+            case SELECTION_MODE_RANGE: {
+                adapter.setDateSelected(date, nowSelected);
+                if (adapter.getSelectedDates().size() > 2) {
+                    adapter.clearSelections();
+                    adapter.setDateSelected(date, nowSelected);  //  re-set because adapter has been cleared
+                    dispatchOnDateSelected(date, nowSelected);
+                } else if (adapter.getSelectedDates().size() == 2) {
+                    List<CalendarDay> dates = adapter.getSelectedDates();
+                    Pair<CalendarDay, CalendarDay> dayPair = new Pair<>(dates.get(0), dates.get(1));
+                    dispatchOnRangeSelected(dayPair);
+                } else {
+                    adapter.setDateSelected(date, nowSelected);
+                    dispatchOnDateSelected(date, nowSelected);
+                }
             }
             break;
             default:

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -423,7 +423,8 @@ public class MaterialCalendarView extends ViewGroup {
      * Change the selection mode of the calendar. The default mode is {@linkplain #SELECTION_MODE_SINGLE}
      *
      * @param mode the selection mode to change to. This must be one of
-     *             {@linkplain #SELECTION_MODE_NONE}, {@linkplain #SELECTION_MODE_SINGLE}, or {@linkplain #SELECTION_MODE_MULTIPLE}.
+     *             {@linkplain #SELECTION_MODE_NONE}, {@linkplain #SELECTION_MODE_SINGLE},
+     *             {@linkplain #SELECTION_MODE_RANGE} or {@linkplain #SELECTION_MODE_MULTIPLE}.
      *             Unknown values will act as {@linkplain #SELECTION_MODE_SINGLE}
      * @see #getSelectionMode()
      * @see #SELECTION_MODE_NONE
@@ -439,7 +440,6 @@ public class MaterialCalendarView extends ViewGroup {
                 clearSelection();
                 break;
             case SELECTION_MODE_SINGLE:
-                this.selectionMode = SELECTION_MODE_SINGLE;
                 if (oldMode == SELECTION_MODE_MULTIPLE || oldMode == SELECTION_MODE_RANGE) {
                     //We should only have one selection now, so we should pick one
                     List<CalendarDay> dates = getSelectedDates();
@@ -448,6 +448,7 @@ public class MaterialCalendarView extends ViewGroup {
                     }
                 }
                 break;
+            default:
             case SELECTION_MODE_NONE:
                 this.selectionMode = SELECTION_MODE_NONE;
                 if (oldMode != SELECTION_MODE_NONE) {
@@ -455,7 +456,6 @@ public class MaterialCalendarView extends ViewGroup {
                     clearSelection();
                 }
                 break;
-            default:
         }
 
         adapter.setSelectionEnabled(selectionMode != SELECTION_MODE_NONE);
@@ -491,6 +491,7 @@ public class MaterialCalendarView extends ViewGroup {
      * @see #SELECTION_MODE_NONE
      * @see #SELECTION_MODE_SINGLE
      * @see #SELECTION_MODE_MULTIPLE
+     * @see #SELECTION_MODE_RANGE
      */
     @SelectionMode
     public int getSelectionMode() {
@@ -1414,7 +1415,7 @@ public class MaterialCalendarView extends ViewGroup {
      * Select a fresh range of date including first day and last day.
      *
      * @param firstDay first day of the range to select
-     * @param lastDay last day of the range to select
+     * @param lastDay  last day of the range to select
      */
     public void selectRange(final CalendarDay firstDay, final CalendarDay lastDay) {
         clearSelection();

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/OnRangeSelectedListener.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/OnRangeSelectedListener.java
@@ -1,0 +1,20 @@
+package com.prolificinteractive.materialcalendarview;
+
+import android.support.annotation.NonNull;
+
+import java.util.List;
+
+/**
+ * The callback used to indicate a range has been selected
+ */
+public interface OnRangeSelectedListener {
+
+    /**
+     * Called when a user selects a range of days.
+     * There is no logic to prevent multiple calls for the same date and state.
+     *
+     * @param widget   the view associated with this listener
+     * @param dates     the dates in the range, in ascending order
+     */
+    void onRangeSelected(@NonNull MaterialCalendarView widget, @NonNull List<CalendarDay> dates);
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.prolificinteractive.materialcalendarview.sample"

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/DynamicSettersActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/DynamicSettersActivity.java
@@ -147,7 +147,7 @@ public class DynamicSettersActivity extends AppCompatActivity {
         showDatePickerDialog(this, widget.getSelectedDate(), new DatePickerDialog.OnDateSetListener() {
             @Override
             public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {
-                widget.setSelectedDate(CalendarDay.from(year, monthOfYear, dayOfMonth));
+                widget.selectRange(CalendarDay.from(2016, 4, 26), CalendarDay.from(2016, 5, 10));
             }
         });
     }
@@ -230,7 +230,8 @@ public class DynamicSettersActivity extends AppCompatActivity {
         CharSequence[] items = {
                 "No Selection",
                 "Single Date",
-                "Multiple Dates"
+                "Multiple Dates",
+                "Range of Dates"
         };
         new AlertDialog.Builder(this)
                 .setTitle("Selection Mode")

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/DynamicSettersActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/DynamicSettersActivity.java
@@ -147,7 +147,7 @@ public class DynamicSettersActivity extends AppCompatActivity {
         showDatePickerDialog(this, widget.getSelectedDate(), new DatePickerDialog.OnDateSetListener() {
             @Override
             public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {
-                widget.selectRange(CalendarDay.from(2016, 4, 26), CalendarDay.from(2016, 5, 10));
+                widget.setSelectedDate(CalendarDay.from(year, monthOfYear, dayOfMonth));
             }
         });
     }


### PR DESCRIPTION
As from @papageorgiouk PR, here is a final version of the select range feature.
- Select range using `SELECTION_MODE_RANGE`
- Select items in between range dates, including first and last date
- Added api endpoint for selecting range (Select range possible even in `SELECTION_MODE_NONE`)
- Added mode in sample app
- Documented methods

@papageorgiouk feel free to review my final version. Credit as well to @damian-aragunde-udc for helping with this.

@ekchang @chahinem @Jogan 

> Fix #245 
> 
> This adds select range functionality. When two dates are selected, the callback returns a sorted (ascending) list of dates in that range. 
> 
> After that, if another date is selected, it clears the previous selection on the widget and waits for a second one for a new range select.
> 
> I tried to keep the documentation style as close to the original as possible. Please forgive any mistakes.
> 
> **Usage**
> 
> Set the new selection mode:
> `mcv.setSelectionMode(MaterialCalendarView.SELECTION_MODE_RANGE);`
> 
> And the listener:
> `mcv.setOnRangeSelectedListener(new OnRangeSelectedListener() {
>            @Override
>             public void onRangeSelected(@NonNull MaterialCalendarView widget, @NonNull List<CalendarDay> dates) {
>                 //  do stuff
>             }
>         });`
> 
> The `List<CalendarDay> dates` is the desired range. It also works with a backwards selection, but the list will always be returned sorted in ascending order.