### PR TITLE
Change DateFormatTitleFormatter for other languages

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/format/DateFormatTitleFormatter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/format/DateFormatTitleFormatter.java
@@ -14,11 +14,11 @@ public class DateFormatTitleFormatter implements TitleFormatter {
     private final DateFormat dateFormat;
 
     /**
-     * Format using "MMMM yyyy" for formatting
+     * Format using "LLLL yyyy" for formatting
      */
     public DateFormatTitleFormatter() {
         this.dateFormat = new SimpleDateFormat(
-                "MMMM yyyy", Locale.getDefault()
+                "LLLL yyyy", Locale.getDefault()
         );
     }
 


### PR DESCRIPTION
#318
 
Change DateFormatTitleFormatter to use LLLL instead of MMMM for month formatting (needed for some context aware languages)

@quentin41500 