### PR TITLE
Incorrect min date used in WeekPagerAdapter

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/WeekPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/WeekPagerAdapter.java
@@ -42,7 +42,7 @@ public class WeekPagerAdapter extends CalendarPagerAdapter<WeekView> {
 
         public Weekly(@NonNull CalendarDay min, @NonNull CalendarDay max, int firstDayOfWeek) {
             this.min = getFirstDayOfWeek(min, firstDayOfWeek);
-            this.count = weekNumberDifference(min, max) + 1;
+            this.count = weekNumberDifference(this.min, max) + 1;
         }
 
         @Override

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/format/DateFormatTitleFormatter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/format/DateFormatTitleFormatter.java
@@ -14,11 +14,11 @@ public class DateFormatTitleFormatter implements TitleFormatter {
     private final DateFormat dateFormat;
 
     /**
-     * Format using "MMMM yyyy" for formatting
+     * Format using "LLLL yyyy" for formatting
      */
     public DateFormatTitleFormatter() {
         this.dateFormat = new SimpleDateFormat(
-                "MMMM yyyy", Locale.getDefault()
+                "LLLL yyyy", Locale.getDefault()
         );
     }
 


### PR DESCRIPTION
#222 

This is a partial fix: should work for most cases especially if you set a min date. I can still generate cases where if you set min date before `April 8, 2006 (2006, 3, 8)` the last page is missing. Will investigate.

@quentin41500 