### PR TITLE
Fix for an issue when a wrong week is selected when switching between  month and week display mode

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/WeekPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/WeekPagerAdapter.java
@@ -67,7 +67,11 @@ public class WeekPagerAdapter extends CalendarPagerAdapter<WeekView> {
 
         private int weekNumberDifference(@NonNull CalendarDay min, @NonNull CalendarDay max) {
             long millisDiff = max.getDate().getTime() - min.getDate().getTime();
-            long dayDiff = TimeUnit.DAYS.convert(millisDiff, TimeUnit.MILLISECONDS);
+
+            int dstOffsetMax = max.getCalendar().get(Calendar.DST_OFFSET);
+            int dstOffsetMin = min.getCalendar().get(Calendar.DST_OFFSET);
+
+            long dayDiff = TimeUnit.DAYS.convert(millisDiff + dstOffsetMax - dstOffsetMin, TimeUnit.MILLISECONDS);
             return (int) (dayDiff / DAYS_IN_WEEK);
         }
 


### PR DESCRIPTION
This should probably fix issue #222 

The problem is that a daylight saving time (DST) was ignored when calculating a number of days between two dates.