### PR TITLE
Support match_parent as a valid tile dimension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -66,6 +66,8 @@ import java.util.List;
  */
 public class MaterialCalendarView extends ViewGroup {
 
+    public static final int INVALID_TILE_DIMENSION = -10;
+
     /**
      * {@linkplain IntDef} annotation for selection mode.
      *
@@ -217,8 +219,8 @@ public class MaterialCalendarView extends ViewGroup {
     private int arrowColor = Color.BLACK;
     private Drawable leftArrowMask;
     private Drawable rightArrowMask;
-    private int tileHeight = -1;
-    private int tileWidth = -1;
+    private int tileHeight = INVALID_TILE_DIMENSION;
+    private int tileWidth = INVALID_TILE_DIMENSION;
     @SelectionMode
     private int selectionMode = SELECTION_MODE_SINGLE;
     private boolean allowClickDaysOutsideCurrentMonth = true;
@@ -288,18 +290,18 @@ public class MaterialCalendarView extends ViewGroup {
                     .setCalendarDisplayMode(CalendarMode.values()[calendarModeIndex])
                     .commit();
 
-            final int tileSize = a.getDimensionPixelSize(R.styleable.MaterialCalendarView_mcv_tileSize, -1);
-            if (tileSize > 0) {
+            final int tileSize = a.getLayoutDimension(R.styleable.MaterialCalendarView_mcv_tileSize, INVALID_TILE_DIMENSION);
+            if (tileSize > INVALID_TILE_DIMENSION) {
                 setTileSize(tileSize);
             }
 
-            final int tileWidth = a.getDimensionPixelSize(R.styleable.MaterialCalendarView_mcv_tileWidth, -1);
-            if (tileWidth > 0) {
+            final int tileWidth = a.getLayoutDimension(R.styleable.MaterialCalendarView_mcv_tileWidth, INVALID_TILE_DIMENSION);
+            if(tileWidth > INVALID_TILE_DIMENSION){
                 setTileWidth(tileWidth);
             }
 
-            final int tileHeight = a.getDimensionPixelSize(R.styleable.MaterialCalendarView_mcv_tileHeight, -1);
-            if (tileHeight > 0) {
+            final int tileHeight = a.getLayoutDimension(R.styleable.MaterialCalendarView_mcv_tileHeight, INVALID_TILE_DIMENSION);
+            if(tileHeight > INVALID_TILE_DIMENSION){
                 setTileHeight(tileHeight);
             }
 
@@ -1523,14 +1525,18 @@ public class MaterialCalendarView extends ViewGroup {
         int measureTileWidth = -1;
         int measureTileHeight = -1;
 
-        if (this.tileWidth > 0 || this.tileHeight > 0) {
+        if (this.tileWidth != INVALID_TILE_DIMENSION || this.tileHeight != INVALID_TILE_DIMENSION) {
             if (this.tileWidth > 0) {
                 //We have a tileWidth set, we should use that
                 measureTileWidth = this.tileWidth;
+            } else {
+                measureTileWidth = desiredTileWidth;
             }
             if (this.tileHeight > 0) {
                 //We have a tileHeight set, we should use that
                 measureTileHeight = this.tileHeight;
+            } else {
+                measureTileHeight = desiredTileHeight;
             }
         } else if (specWidthMode == MeasureSpec.EXACTLY) {
             if (specHeightMode == MeasureSpec.EXACTLY) {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -26,9 +26,18 @@
         <attr name="mcv_weekDayLabels" format="reference" />
         <attr name="mcv_monthLabels" format="reference" />
 
-        <attr name="mcv_tileSize" format="dimension" />
-        <attr name="mcv_tileHeight" format="dimension" />
-        <attr name="mcv_tileWidth" format="dimension" />
+        <!-- We want to accept match_parent but not wrap_content. It'd be better if we could
+        point to the real match_parent constant, but since it hasn't change since API 1,
+        I think it's safe to hardcode it-->
+        <attr name="mcv_tileSize" format="dimension" >
+            <enum name="match_parent" value="-1" />
+        </attr>
+        <attr name="mcv_tileHeight" format="dimension" >
+            <enum name="match_parent" value="-1" />
+        </attr>
+        <attr name="mcv_tileWidth" format="dimension" >
+            <enum name="match_parent" value="-1" />
+        </attr>
 
         <attr name="mcv_firstDayOfWeek" format="enum">
             <enum name="sunday" value="1" />

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -166,6 +166,24 @@
         </activity>
 
         <activity
+            android:name=".CustomTileDimensions"
+            android:label="@string/title_activity_custom_tile_size"
+            android:parentActivityName="com.prolificinteractive.materialcalendarview.sample.MainActivity"
+            >
+
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.prolificinteractive.materialcalendarview.sample.MainActivity"
+                />
+
+            <intent-filter>
+                <action android:name="android.intent.action.RUN" />
+                <category android:name="com.prolificinteractive.materialcalendarview.sample.SAMPLE" />
+            </intent-filter>
+
+        </activity>
+
+        <activity
             android:name="com.prolificinteractive.materialcalendarview.sample.DialogsActivity"
             android:label="@string/title_activity_dialogs"
             android:parentActivityName="com.prolificinteractive.materialcalendarview.sample.MainActivity"

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/CustomTileDimensions.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/CustomTileDimensions.java
@@ -1,0 +1,90 @@
+package com.prolificinteractive.materialcalendarview.sample;
+
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.LinearLayout;
+import android.widget.NumberPicker;
+
+import com.prolificinteractive.materialcalendarview.MaterialCalendarView;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
+/**
+ * Created by maragues on 17/06/16.
+ */
+public class CustomTileDimensions extends AppCompatActivity {
+
+  @Bind(R.id.calendarView)
+  MaterialCalendarView widget;
+
+  private int currentTileWidth;
+  private int currentTileHeight;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_custom_tile);
+    ButterKnife.bind(this);
+
+    currentTileWidth = MaterialCalendarView.DEFAULT_TILE_SIZE_DP;
+    currentTileHeight = MaterialCalendarView.DEFAULT_TILE_SIZE_DP;
+  }
+
+  @OnClick(R.id.custom_tile_match_parent)
+  public void onMatchParentClick() {
+    widget.setTileSize(LinearLayout.LayoutParams.MATCH_PARENT);
+  }
+
+  @OnClick(R.id.custom_tile_width_match_parent)
+  public void onWidthMatchParentClick() {
+    widget.setTileWidth(LinearLayout.LayoutParams.MATCH_PARENT);
+  }
+
+  @OnClick(R.id.custom_tile_height_match_parent)
+  public void onHeightMatchParentClick() {
+    widget.setTileHeight(LinearLayout.LayoutParams.MATCH_PARENT);
+  }
+
+  @OnClick(R.id.custom_tile_width_size)
+  public void onWidthClick() {
+    final NumberPicker view = new NumberPicker(this);
+    view.setMinValue(24);
+    view.setMaxValue(64);
+    view.setWrapSelectorWheel(false);
+    view.setValue(currentTileWidth);
+    new AlertDialog.Builder(this)
+            .setView(view)
+            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+              @Override
+              public void onClick(@NonNull DialogInterface dialog, int which) {
+                currentTileWidth = view.getValue();
+                widget.setTileWidthDp(currentTileWidth);
+              }
+            })
+            .show();
+  }
+
+  @OnClick(R.id.custom_tile_height_size)
+  public void onHeightClick() {
+    final NumberPicker view = new NumberPicker(this);
+    view.setMinValue(24);
+    view.setMaxValue(64);
+    view.setWrapSelectorWheel(false);
+    view.setValue(currentTileHeight);
+    new AlertDialog.Builder(this)
+            .setView(view)
+            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+              @Override
+              public void onClick(@NonNull DialogInterface dialog, int which) {
+                currentTileHeight = view.getValue();
+                widget.setTileHeightDp(currentTileHeight);
+              }
+            })
+            .show();
+  }
+}

--- a/sample/src/main/res/layout/activity_custom_tile.xml
+++ b/sample/src/main/res/layout/activity_custom_tile.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        tools:context=".BasicActivity"
+        >
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <Button
+                android:text="Custom width"
+                android:id="@+id/custom_tile_width_size"
+                android:layout_width="0dp"
+                android:layout_weight="0.25"
+                android:layout_height="match_parent"/>
+
+            <Button
+                android:text="Match parent width"
+                android:id="@+id/custom_tile_width_match_parent"
+                android:layout_width="0dp"
+                android:layout_weight="0.25"
+                android:layout_height="match_parent"/>
+
+            <Button
+                android:text="Custom height"
+                android:id="@+id/custom_tile_height_size"
+                android:layout_width="0dp"
+                android:layout_weight="0.25"
+                android:layout_height="match_parent"/>
+
+            <Button
+                android:text="Match parent height"
+                android:id="@+id/custom_tile_height_match_parent"
+                android:layout_width="0dp"
+                android:layout_weight="0.25"
+                android:layout_height="match_parent"/>
+        </LinearLayout>
+
+        <Button
+            android:text="Match height and width"
+            android:id="@+id/custom_tile_match_parent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+        <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+            android:id="@+id/calendarView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="title_activity_customize_xml">XML Customization Example</string>
     <string name="title_activity_customize_code">Programmatic Customization Example</string>
     <string name="title_activity_dynamic_setters">Dynamic Setters Test</string>
+    <string name="title_activity_custom_tile_size">Custom tile width/height</string>
     <string name="title_activity_old_calendar">Old CalendarView</string>
     <string name="title_activity_dialogs">Calendar in Dialogs</string>
     <string name="title_activity_decorators">Calendar with Decorators</string>


### PR DESCRIPTION
You can now pass match_parent to tileSize, tileWidth and tileHeight

Closes https://github.com/prolificinteractive/material-calendarview/issues/349