### PR TITLE
fix bug that calendar does not go to correct month view after a date is clicked

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -1433,14 +1433,23 @@ public class MaterialCalendarView extends ViewGroup {
     protected void onDateClicked(DayView dayView) {
         final int currentMonth = getCurrentDate().getMonth();
         final int selectedMonth = dayView.getDate().getMonth();
+        final int currentYear = getCurrentDate().getYear();
+        final int selectedYear = dayView.getDate().getYear();
 
         if (calendarMode == CalendarMode.MONTHS) {
             if (allowClickDaysOutsideCurrentMonth || currentMonth == selectedMonth) {
-                if (currentMonth > selectedMonth) {
+                if (currentYear == selectedYear) {
+                    if (currentMonth > selectedMonth) {
+                        goToPrevious();
+                    } else if (currentMonth < selectedMonth) {
+                        goToNext();
+                    }
+                } else if (currentYear > selectedYear) {
                     goToPrevious();
-                } else if (currentMonth < selectedMonth) {
+                } else if (currentYear < selectedYear) {
                     goToNext();
                 }
+
                 onDateClicked(dayView.getDate(), !dayView.isChecked());
             }
         } else {


### PR DESCRIPTION
fix issue #374 .

former code only compare current month and month of the selected date to determine whether to go to next month or prev month. This only works if the compared months are in the same year.

If a date in next Jan is clicked in Dec month view, selectedMonth will be 0 and less than currentMonth. And calendar will go to prev month which is Nov while calendar is supposed to go to next Jan.