### PR TITLE
Fix clicking january from december in materialcalendarview

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -1203,7 +1203,7 @@ public class MaterialCalendarView extends ViewGroup {
     /**
      * By default, the calendar will take up all the space needed to show any month (6 rows).
      * By enabling dynamic height, the view will change height dependant on the visible month.
-     * <p>
+     * <p/>
      * This means months that only need 5 or 4 rows to show the entire month will only take up
      * that many rows, and will grow and shrink as necessary.
      *
@@ -1431,16 +1431,21 @@ public class MaterialCalendarView extends ViewGroup {
      * @param dayView
      */
     protected void onDateClicked(DayView dayView) {
-        final int currentMonth = getCurrentDate().getMonth();
-        final int selectedMonth = dayView.getDate().getMonth();
+        CalendarDay currentDate = getCurrentDate();
+        CalendarDay selectedDate = dayView.getDate();
+        final int currentMonth = currentDate.getMonth();
+        final int selectedMonth = selectedDate.getMonth();
 
         if (calendarMode == CalendarMode.MONTHS) {
-            if (allowClickDaysOutsideCurrentMonth || currentMonth == selectedMonth) {
-                if (currentMonth > selectedMonth) {
+            if (currentMonth == selectedMonth) {
+                onDateClicked(dayView.getDate(), !dayView.isChecked());
+            } else if (allowClickDaysOutsideCurrentMonth) {
+                if (currentDate.isAfter(selectedDate)) {
                     goToPrevious();
-                } else if (currentMonth < selectedMonth) {
+                } else if (currentDate.isBefore(selectedDate)) {
                     goToNext();
                 }
+
                 onDateClicked(dayView.getDate(), !dayView.isChecked());
             }
         } else {
@@ -1789,7 +1794,7 @@ public class MaterialCalendarView extends ViewGroup {
 
         /**
          * Sets the first day of the week.
-         * <p>
+         * <p/>
          * Uses the java.util.Calendar day constants.
          *
          * @param day The first day of the week as a java.util.Calendar day constant.


### PR DESCRIPTION
If there is a MaterialCalendarView that has the setting setAllowClickDaysOutsideCurrentMonth(true) set, and the calendar shows December, if you click a date in January it goes back to November. I have coded up a fix but I do not have push permission to make a PR. This is on year boundaries, since the month 11 (december) is greater than the month 0 (january) it was going back a month instead of forward a month.

Cheers,
Brian