### PR TITLE
Fix - Weekday label of Sunday show incorrect text

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/format/CalendarWeekDayFormatter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/format/CalendarWeekDayFormatter.java
@@ -20,7 +20,12 @@ public class CalendarWeekDayFormatter implements WeekDayFormatter {
      * @param calendar Calendar to retrieve formatting information from
      */
     public CalendarWeekDayFormatter(Calendar calendar) {
+        // recompute all fields of the calendar based on current date
+        // See "Getting and Setting Calendar Field Values"
+        // in https://developer.android.com/reference/java/util/Calendar.html
+        calendar.get(Calendar.DAY_OF_WEEK);  // Any fields to get is OK to recompute all fields in the calendar.
         this.calendar = calendar;
+
     }
 
     /**

--- a/library/src/test/java/com/prolificinteractive/materialcalendarview/format/CalendarWeekDayFormatterTest.java
+++ b/library/src/test/java/com/prolificinteractive/materialcalendarview/format/CalendarWeekDayFormatterTest.java
@@ -1,0 +1,64 @@
+package com.prolificinteractive.materialcalendarview.format;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class CalendarWeekDayFormatterTest {
+
+    public CalendarWeekDayFormatter formatter;
+    public Locale defaultLocaleOriginal;
+
+    @Before
+    public void setUp() throws Exception {
+        defaultLocaleOriginal = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
+        formatter = new CalendarWeekDayFormatter();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Locale.setDefault(defaultLocaleOriginal);
+    }
+
+    @Test
+    public void testFormattedDayOfWeek_Sunday() throws Exception {
+        assertThat(formatter.format(Calendar.SUNDAY).toString(), is("Sun"));
+    }
+
+    @Test
+    public void testFormattedDayOfWeek_Monday() throws Exception {
+        assertThat(formatter.format(Calendar.MONDAY).toString(), is("Mon"));
+    }
+
+    @Test
+    public void testFormattedDayOfWeek_Tuesday() throws Exception {
+        assertThat(formatter.format(Calendar.TUESDAY).toString(), is("Tue"));
+    }
+
+    @Test
+    public void testFormattedDayOfWeek_Wednesday() throws Exception {
+        assertThat(formatter.format(Calendar.WEDNESDAY).toString(), is("Wed"));
+    }
+
+    @Test
+    public void testFormattedDayOfWeek_Thursday() throws Exception {
+        assertThat(formatter.format(Calendar.THURSDAY).toString(), is("Thu"));
+    }
+
+    @Test
+    public void testFormattedDayOfWeek_Friday() throws Exception {
+        assertThat(formatter.format(Calendar.FRIDAY).toString(), is("Fri"));
+    }
+
+    @Test
+    public void shouldReturnCorrectFormattedEnglishTextOfSaturday() throws Exception {
+        assertThat(formatter.format(Calendar.SATURDAY).toString(), is("Sat"));
+    }
+}


### PR DESCRIPTION
Hello,

I find that the weekday label of Sunday shows today's day-of-week instead of Sunday
if `CalendarWeekDayFormatter` is set explicitly by using `setWeekDayFormatter()`.

`Activity` has the following code to reproduce it:

```java
    @Override
    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);
        MaterialCalendarView materialCalendarView = (MaterialCalendarView) findViewById(R.id.calendarView);
        materialCalendarView.setWeekDayFormatter(new CalendarWeekDayFormatter());
    }
```

The screenshot (taken on 2016-09-24 Sat) is as follows.
![screenshot_1474737340](https://cloud.githubusercontent.com/assets/3140018/18810163/ffd423a6-82c9-11e6-90b0-90a43b6d6b04.png)

With the help of a debugger,
I find that **only the first call** of `CalendarWeekDayFormatter.format()` returns wrong text.

`CalendarWeekDayFormatter` is initialized with the return value of
`CalendarUtils.getInstance()` which year/month/date is set to.

Because `CalendarWeekDayFormatter.format()` calls `calendar.set(DAY_OF_WEEK, dayOfWeek)`
without calling of `calendar.get()`, `Calendar` becomes [conflict
state (year/month/date vs day-of-week)](http://stackoverflow.com/a/6722603/2925059).

This PR avoids that scenario by calling `Calendar.get()` in the constructor.
Test code is also included.