### PR TITLE
Bschnack/save date

### DIFF
--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/DynamicSettersActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/DynamicSettersActivity.java
@@ -90,6 +90,13 @@ public class DynamicSettersActivity extends AppCompatActivity {
                 .show();
     }
 
+    @OnCheckedChanged(R.id.enable_save_current_position)
+    void onSaveCurrentPositionChecked(boolean checked) {
+        widget.state().edit()
+                .setSaveCurrentPosition(checked)
+                .commit();
+    }
+
     @OnCheckedChanged(R.id.check_text_appearance)
     void onTextAppearanceChecked(boolean checked) {
         if (checked) {

--- a/sample/src/main/res/layout/activity_dynamic_setters.xml
+++ b/sample/src/main/res/layout/activity_dynamic_setters.xml
@@ -225,6 +225,22 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            >
+
+            <CheckBox
+                android:id="@+id/enable_save_current_position"
+                android:text="Enable save current position"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                />
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </ScrollView>


### PR DESCRIPTION
Hello,

This is to add more functionality when switching between month and week view such that the current paged position is taken into account when deciding where to be in the new month/week view. For example, if a user is in a month view and scrolls over a few months, when the user switches to week view, they will go back to today. I have added it into the commit state to not break any existing behavior apps might expect with the current implementation making this an opt in feature rather than the default.

My new logic is: When switching from month to month view or week to week view, do not change which page you are looking at. When switching from month to week view and a selected date is in view of the month, show week view around selected date. Otherwise, show the first week of the month. When switching from week to month view and a selected date is in view of the week, show month that selected date exists in. Otherwise, show the month that corresponds to the end of the week. The reason I chose the end of the week is because when going from week to month to week to month I wanted the views to not change and more often then not, if I choose the first week then the first few days in the week are in the previous month.

Cheers,
Brian
