### PR TITLE
Sample - Added examples of MCV list 

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -3,7 +3,3 @@ Material CalendarView Sample App
 
 The sample app contains a mixture of implementations to help test and debug during development,
 and to help new users understand how to implement some functionality.
-
-## TODO
-
-We need to revamp/reorganize the samples to be less redundant and more comprehensive.

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -183,6 +183,40 @@
 
         </activity>
 
+        <activity
+            android:name="com.prolificinteractive.materialcalendarview.sample.MultipleViewActivity"
+            android:label="@string/title_activity_multiple_view"
+            android:parentActivityName="com.prolificinteractive.materialcalendarview.sample.MainActivity"
+            >
+
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.prolificinteractive.materialcalendarview.sample.MainActivity"
+                />
+
+            <intent-filter>
+                <action android:name="android.intent.action.RUN" />
+                <category android:name="com.prolificinteractive.materialcalendarview.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name="com.prolificinteractive.materialcalendarview.sample.MultipleSizeActivity"
+            android:label="@string/title_activity_multiple_size"
+            android:parentActivityName="com.prolificinteractive.materialcalendarview.sample.MainActivity"
+            >
+
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.prolificinteractive.materialcalendarview.sample.MainActivity"
+                />
+
+            <intent-filter>
+                <action android:name="android.intent.action.RUN" />
+                <category android:name="com.prolificinteractive.materialcalendarview.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/MultipleSizeActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/MultipleSizeActivity.java
@@ -1,0 +1,16 @@
+package com.prolificinteractive.materialcalendarview.sample;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * Displays various ways of sizing CalendarView
+ */
+public class MultipleSizeActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_multiple_size);
+    }
+}

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/MultipleViewActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/MultipleViewActivity.java
@@ -1,0 +1,82 @@
+package com.prolificinteractive.materialcalendarview.sample;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.prolificinteractive.materialcalendarview.MaterialCalendarView;
+
+import java.util.Calendar;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+
+/**
+ * In response to the issue comment at
+ * https://github.com/prolificinteractive/material-calendarview/issues/8#issuecomment-241205704
+ * , test activity with multiple MaterialCalendarViews
+ */
+public class MultipleViewActivity extends AppCompatActivity{
+    //number of MaterialCalendarViews to display in list
+    static final int NUM_ENTRIES = 3;
+
+    @Bind(R.id.calendar_list)
+    RecyclerView calendarList;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_multiple);
+        ButterKnife.bind(this);
+
+        //setup RecyclerView
+        calendarList.setLayoutManager(new LinearLayoutManager(this));
+        calendarList.setAdapter(new MultipleViewAdapter(this));
+    }
+
+    /**
+     * Adapter for RecyclerView
+     */
+    class MultipleViewAdapter extends RecyclerView.Adapter<MultipleViewAdapter.EntryViewHolder> {
+        final LayoutInflater inflater;
+
+        MultipleViewAdapter(Context context) {
+            inflater = LayoutInflater.from(context);
+        }
+
+        @Override
+        public EntryViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            View view = inflater.inflate(R.layout.calendar_list_entry, parent, false);
+            return new EntryViewHolder(view);
+        }
+
+        @Override
+        public int getItemCount() {
+            return NUM_ENTRIES;
+        }
+
+        @Override
+        public void onBindViewHolder(EntryViewHolder holder, int position) {
+            //set selected date to today
+            Calendar instance = Calendar.getInstance();
+            holder.calendarView.setSelectedDate(instance.getTime());
+        }
+
+        /**
+         * View holder for list entry
+         */
+        class EntryViewHolder extends RecyclerView.ViewHolder {
+            final MaterialCalendarView calendarView;
+
+            EntryViewHolder(View itemView) {
+                super(itemView);
+                calendarView = (MaterialCalendarView) itemView.findViewById(R.id.list_entry);
+            }
+        }
+    }
+}

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/MultipleViewActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/MultipleViewActivity.java
@@ -25,8 +25,7 @@ public class MultipleViewActivity extends AppCompatActivity{
     //number of MaterialCalendarViews to display in list
     static final int NUM_ENTRIES = 3;
 
-    @Bind(R.id.calendar_list)
-    RecyclerView calendarList;
+    @Bind(R.id.calendar_list) RecyclerView calendarList;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -45,13 +44,13 @@ public class MultipleViewActivity extends AppCompatActivity{
     class MultipleViewAdapter extends RecyclerView.Adapter<MultipleViewAdapter.EntryViewHolder> {
         final LayoutInflater inflater;
 
-        MultipleViewAdapter(Context context) {
+        MultipleViewAdapter(final Context context) {
             inflater = LayoutInflater.from(context);
         }
 
         @Override
         public EntryViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-            View view = inflater.inflate(R.layout.calendar_list_entry, parent, false);
+            final View view = inflater.inflate(R.layout.calendar_list_entry, parent, false);
             return new EntryViewHolder(view);
         }
 
@@ -63,7 +62,7 @@ public class MultipleViewActivity extends AppCompatActivity{
         @Override
         public void onBindViewHolder(EntryViewHolder holder, int position) {
             //set selected date to today
-            Calendar instance = Calendar.getInstance();
+            final Calendar instance = Calendar.getInstance();
             holder.calendarView.setSelectedDate(instance.getTime());
         }
 
@@ -73,7 +72,7 @@ public class MultipleViewActivity extends AppCompatActivity{
         class EntryViewHolder extends RecyclerView.ViewHolder {
             final MaterialCalendarView calendarView;
 
-            EntryViewHolder(View itemView) {
+            EntryViewHolder(final View itemView) {
                 super(itemView);
                 calendarView = (MaterialCalendarView) itemView.findViewById(R.id.list_entry);
             }

--- a/sample/src/main/res/layout/activity_multiple.xml
+++ b/sample/src/main/res/layout/activity_multiple.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/calendar_list"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context=".MultipleViewActivity"
+    />

--- a/sample/src/main/res/layout/activity_multiple_size.xml
+++ b/sample/src/main/res/layout/activity_multiple_size.xml
@@ -15,7 +15,7 @@
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         >
         <TextView
             android:id="@+id/textNormalView"

--- a/sample/src/main/res/layout/activity_multiple_size.xml
+++ b/sample/src/main/res/layout/activity_multiple_size.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context=".MultipleSizeActivity"
+    >
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
+        <TextView
+            android:id="@+id/textNormalView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_normal"
+            />
+
+        <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+            android:id="@+id/normalView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            />
+
+        <TextView
+            android:id="@+id/textSmallView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_small"
+            />
+
+        <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+            android:id="@+id/smallView"
+            android:layout_width="@dimen/calendar_size_small"
+            android:layout_height="@dimen/calendar_size_small"
+            />
+
+        <TextView
+            android:id="@+id/textMediumView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_medium"
+            />
+
+        <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+            android:id="@+id/mediumView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:mcv_tileSize="@dimen/tile_size_medium"
+            />
+
+        <TextView
+            android:id="@+id/textThinView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_thin"
+            />
+
+        <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+            android:id="@+id/thinView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:mcv_tileWidth="@dimen/tile_size_small"
+            app:mcv_tileHeight="@dimen/tile_size_medium"
+            />
+
+        <TextView
+            android:id="@+id/textWideView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/label_wide"/>
+
+        <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+            android:id="@+id/wideView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:mcv_tileWidth="@dimen/tile_size_medium"
+            app:mcv_tileHeight="@dimen/tile_size_small"
+            />
+    </LinearLayout>
+
+</ScrollView>

--- a/sample/src/main/res/layout/calendar_list_entry.xml
+++ b/sample/src/main/res/layout/calendar_list_entry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.prolificinteractive.materialcalendarview.MaterialCalendarView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/list_entry"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    />

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -2,4 +2,8 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+
+    <dimen name="calendar_size_small">100dp</dimen>
+    <dimen name="tile_size_medium">32dp</dimen>
+    <dimen name="tile_size_small">16dp</dimen>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="title_activity_dialogs">Calendar in Dialogs</string>
     <string name="title_activity_decorators">Calendar with Decorators</string>
     <string name="title_activity_basic_modes">Calendar with Dynamic Modes</string>
+    <string name="title_activity_multiple_view">Multiple Basic Calendars</string>
+    <string name="title_activity_multiple_size">Many-Sized Calendars</string>
 
     <string-array name="custom_weekdays">
         <item>Su</item>
@@ -38,5 +40,11 @@
         <item>Nov</item>
         <item>DEC</item>
     </string-array>
+
+    <string name="label_normal">Fitted for screen (common use)</string>
+    <string name="label_small">Fitted for small layout parameters</string>
+    <string name="label_medium">Tile size specified</string>
+    <string name="label_thin">Tile width and height specified (thin)</string>
+    <string name="label_wide">Tile width and height specified (wide)</string>
 
 </resources>


### PR DESCRIPTION
From #420 :

> Fixes #404 , by adding more sample Activities. In the end, all I added that we discussed was having multiple MaterialCalendarViews on one screen, both in RecyclerView form and in LinearLayout form. In the latter, I also demonstrated the various ways to size a calendar, which wasn't demonstrated by the other samples. I didn't add an Activity with multiple decorators because the existing BasicActivityDecorated already does that. After writing code for a version that used Data Binding, I decided it wasn't a good thing to demonstrate, because some of the XML values can only be programmatically set using the state builder, so it causes an error if you try to use data binding with them. Since this is potentially unintuitive, I thought it best not to showcase it. Support for this is a potential future feature to include,
> 
> I also removed the TODO from the sample's README.