### PR TITLE
Fixed MaterialCalendarView overlapping or drawing outside the window

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -1576,8 +1576,8 @@ public class MaterialCalendarView extends ViewGroup {
             }
         } else if (specWidthMode == MeasureSpec.EXACTLY) {
             if (specHeightMode == MeasureSpec.EXACTLY) {
-                //Pick the larger of the two explicit sizes
-                measureTileSize = Math.max(desiredTileWidth, desiredTileHeight);
+                //Pick the smaller of the two explicit sizes
+                measureTileSize = Math.min(desiredTileWidth, desiredTileHeight);
             } else {
                 //Be the width size the user wants
                 measureTileSize = desiredTileWidth;


### PR DESCRIPTION
MaterialCalendarView uses the maximum value for tile size out of possible width and height, which frequently causes the View to clip out of the bounds of the screen or parent View. I don't think this is intended functionality since the only example that uses both `width`and `height = match_parent` (`activity_custom_tile.xml`) occupies a square or a scrolling view, hiding incorrect scaling behavior.
If this change isn't suitable, perhaps looking at the `doMeasure()` method of an `ImageView` with fixed aspect ratio would shed some light on a way to scale the View more robustly.
