### PR TITLE
Fixed resize view

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -1574,15 +1574,15 @@ public class MaterialCalendarView extends ViewGroup {
             } else {
                 measureTileHeight = desiredTileHeight;
             }
-        } else if (specWidthMode == MeasureSpec.EXACTLY) {
+        } else if (specWidthMode == MeasureSpec.EXACTLY || specWidthMode == MeasureSpec.AT_MOST) {
             if (specHeightMode == MeasureSpec.EXACTLY) {
-                //Pick the larger of the two explicit sizes
-                measureTileSize = Math.max(desiredTileWidth, desiredTileHeight);
+                //Pick the smaller of the two explicit sizes
+                measureTileSize = Math.min(desiredTileWidth, desiredTileHeight);
             } else {
                 //Be the width size the user wants
                 measureTileSize = desiredTileWidth;
             }
-        } else if (specHeightMode == MeasureSpec.EXACTLY) {
+        } else if (specHeightMode == MeasureSpec.EXACTLY || specHeightMode == MeasureSpec.AT_MOST) {
             //Be the height size the user wants
             measureTileSize = desiredTileHeight;
         }


### PR DESCRIPTION
If we use `match_parent` for the `MaterialCalendarView` but the size available is not enough, the view was truncated.

Fix for https://github.com/prolificinteractive/material-calendarview/issues/416
Same but better fix for PR https://github.com/prolificinteractive/material-calendarview/pull/435
