### PR TITLE
Bug Fix: decorator rendering with customer tile dimensions on API Level 21

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
@@ -167,6 +167,7 @@ class DayView extends CheckedTextView {
     }
 
     private final Rect tempRect = new Rect();
+    private final Rect circleDrawableRect = new Rect();
 
     @Override
     protected void onDraw(@NonNull Canvas canvas) {
@@ -176,7 +177,7 @@ class DayView extends CheckedTextView {
             customBackground.draw(canvas);
         }
 
-        mCircleDrawable.setBounds(tempRect);
+        mCircleDrawable.setBounds(circleDrawableRect);
 
         super.onDraw(canvas);
     }
@@ -185,7 +186,7 @@ class DayView extends CheckedTextView {
         if (selectionDrawable != null) {
             setBackgroundDrawable(selectionDrawable);
         } else {
-            mCircleDrawable = generateBackground(selectionColor, fadeTime, tempRect);
+            mCircleDrawable = generateBackground(selectionColor, fadeTime, circleDrawableRect);
             setBackgroundDrawable(mCircleDrawable);
         }
     }
@@ -265,14 +266,17 @@ class DayView extends CheckedTextView {
 
     private void calculateBounds(int width, int height) {
         final int radius = Math.min(height, width);
-        // Lollipop platform bug. Rect offset needs to be divided by 4 instead of 2
-        final int offsetDivisor = Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP ? 4 : 2;
-        final int offset = Math.abs(height - width) / offsetDivisor;
+        final int offset = Math.abs(height - width) / 2;
+
+        // Lollipop platform bug. Circle drawable offset needs to be half of normal offset
+        final int circleOffset = Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP ? offset / 2 : offset;
 
         if (width >= height) {
             tempRect.set(offset, 0, radius + offset, height);
+            circleDrawableRect.set(circleOffset, 0, radius + circleOffset, height);
         } else {
             tempRect.set(0, offset, width, radius + offset);
+            circleDrawableRect.set(0, circleOffset, width, radius + circleOffset);
         }
     }
 }

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/CustomTileDimensions.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/CustomTileDimensions.java
@@ -1,6 +1,7 @@
 package com.prolificinteractive.materialcalendarview.sample;
 
 import android.content.DialogInterface;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AlertDialog;
@@ -8,6 +9,9 @@ import android.support.v7.app.AppCompatActivity;
 import android.widget.LinearLayout;
 import android.widget.NumberPicker;
 
+import com.prolificinteractive.materialcalendarview.CalendarDay;
+import com.prolificinteractive.materialcalendarview.DayViewDecorator;
+import com.prolificinteractive.materialcalendarview.DayViewFacade;
 import com.prolificinteractive.materialcalendarview.MaterialCalendarView;
 
 import butterknife.Bind;
@@ -33,6 +37,8 @@ public class CustomTileDimensions extends AppCompatActivity {
 
     currentTileWidth = MaterialCalendarView.DEFAULT_TILE_SIZE_DP;
     currentTileHeight = MaterialCalendarView.DEFAULT_TILE_SIZE_DP;
+
+    widget.addDecorator(new TodayDecorator());
   }
 
   @OnClick(R.id.custom_tile_match_parent)
@@ -86,5 +92,26 @@ public class CustomTileDimensions extends AppCompatActivity {
               }
             })
             .show();
+  }
+
+  private class TodayDecorator implements DayViewDecorator {
+
+    private final CalendarDay today;
+    private final Drawable backgroundDrawable;
+
+    public TodayDecorator() {
+      today = CalendarDay.today();
+      backgroundDrawable = getResources().getDrawable(R.drawable.today_circle_background);
+    }
+
+    @Override
+    public boolean shouldDecorate(CalendarDay day) {
+      return today.equals(day);
+    }
+
+    @Override
+    public void decorate(DayViewFacade view) {
+      view.setBackgroundDrawable(backgroundDrawable);
+    }
   }
 }

--- a/sample/src/main/res/drawable/today_circle_background.xml
+++ b/sample/src/main/res/drawable/today_circle_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <solid android:color="#44afcc" />
+
+</shape>


### PR DESCRIPTION
Recently I found a rendering bug when using decorators with custom tile dimensions on API Level 21 (Lollipop):

![image](https://cloud.githubusercontent.com/assets/1420597/21327628/1a142adc-c5fe-11e6-861b-125b31d0bb0c.png)

It's caused by some special case handling in DayView.java and I believe it wasn't an issue until the support for custom tile dimensions was added to address #132. There is actually even some conversation about this bug on that issue but it looks like it hasn't been addressed since then.

The easiest way to reproduce the bug is to add a DayViewDecorator to the MaterialCalendarView in the CustomTileDimensions.java sample. Then, on an Android device running API Level 21, open the CustomTileDimensions Activity and press the "MATCH PARENT WIDTH" button. You can see that the decorator does not align correctly with the selection drawable, because it is slightly off-center to the left. Rotate the device to see the bug more exaggerated, because there is more horizontal space to fill.