### PR TITLE
Memory leak due to static reference

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -168,7 +168,7 @@ public class MaterialCalendarView extends ViewGroup {
     private static final int DEFAULT_MAX_WEEKS = 6;
     private static final int DAY_NAMES_ROW = 1;
 
-    private static final TitleFormatter DEFAULT_TITLE_FORMATTER = new DateFormatTitleFormatter();
+    private final TitleFormatter DEFAULT_TITLE_FORMATTER = new DateFormatTitleFormatter();
     private final TitleChanger titleChanger;
 
     private final TextView title;


### PR DESCRIPTION
TitleFormatter holds context reference, so either we need to change the context to application context or we should not make static TitleFormatter object