### PR TITLE
add support to RTL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }

--- a/library/src/main/java/android/support/v4/view/BetterViewPager.java
+++ b/library/src/main/java/android/support/v4/view/BetterViewPager.java
@@ -3,6 +3,8 @@ package android.support.v4.view;
 import android.content.Context;
 import android.util.AttributeSet;
 
+import com.prolificinteractive.materialcalendarview.LocalUtils;
+
 /**
  * {@linkplain #setChildrenDrawingOrderEnabledCompat(boolean)} does some reflection that isn't needed.
  * And was making view creation time rather large. So lets override it and make it better!
@@ -11,6 +13,8 @@ public class BetterViewPager extends ViewPager {
 
     public BetterViewPager(Context context) {
         super(context);
+        if (LocalUtils.isRTL())
+            this.setRotationY(180);
     }
 
     public BetterViewPager(Context context, AttributeSet attrs) {

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
@@ -19,7 +19,6 @@ import java.util.List;
 import static com.prolificinteractive.materialcalendarview.MaterialCalendarView.SHOW_DEFAULTS;
 import static com.prolificinteractive.materialcalendarview.MaterialCalendarView.showOtherMonths;
 import static java.util.Calendar.DATE;
-import static java.util.Calendar.DAY_OF_WEEK;
 
 abstract class CalendarPagerView extends ViewGroup implements View.OnClickListener {
 
@@ -42,7 +41,14 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
     public CalendarPagerView(@NonNull MaterialCalendarView view,
                              CalendarDay firstViewDay,
                              int firstDayOfWeek) {
+
         super(view.getContext());
+
+        if (LocalUtils.isRTL()) {
+            this.setRotationY(180);
+        }
+
+
         this.mcv = view;
         this.firstViewDay = firstViewDay;
         this.firstDayOfWeek = firstDayOfWeek;
@@ -258,12 +264,14 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
      */
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        final int parentWidth = getWidth();
         final int count = getChildCount();
-
         final int parentLeft = 0;
+        final int parentRight = parentWidth;
 
         int childTop = 0;
         int childLeft = parentLeft;
+        int childRight = parentRight;
 
         for (int i = 0; i < count; i++) {
             final View child = getChildAt(i);
@@ -271,13 +279,18 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
             final int width = child.getMeasuredWidth();
             final int height = child.getMeasuredHeight();
 
-            child.layout(childLeft, childTop, childLeft + width, childTop + height);
-
-            childLeft += width;
+            if (LocalUtils.isRTL()) {
+                child.layout(childRight - width, childTop, childRight, childTop + height);
+                childRight -= width;
+            } else {
+                child.layout(childLeft, childTop, childLeft + width, childTop + height);
+                childLeft += width;
+            }
 
             //We should warp every so many children
             if (i % DEFAULT_DAYS_IN_WEEK == (DEFAULT_DAYS_IN_WEEK - 1)) {
                 childLeft = parentLeft;
+                childRight = parentRight;
                 childTop += height;
             }
 

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/LocalUtils.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/LocalUtils.java
@@ -1,0 +1,19 @@
+package com.prolificinteractive.materialcalendarview;
+
+import java.util.Locale;
+
+/**
+ * Created by Anas AlaaEldin on 5/12/2017.
+ */
+
+public class LocalUtils {
+    public static boolean isRTL() {
+        return isRTL(Locale.getDefault());
+    }
+
+    private static boolean isRTL(Locale locale) {
+        final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
+        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
+                directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+    }
+}


### PR DESCRIPTION
add support to RTL for material-calendarview for the following cases: 

-Swipe right increase months or weeks in RTL by adding support to RTL in BetterViewPager
-in RTL CalendarPagerView draw month and weekday name and number from right to left 
-firstDayOfWeek start from right in RTL mood.

fix the following issues #560  #485 