### PR TITLE
MaterialCalendarView selectRange NullPointerException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
+        classpath 'com.android.tools.build:gradle:2.3.2'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -1468,7 +1468,9 @@ public class MaterialCalendarView extends ViewGroup {
      */
     public void selectRange(final CalendarDay firstDay, final CalendarDay lastDay) {
         clearSelection();
-        if (firstDay.isAfter(lastDay)) {
+        if (firstDay == null || lastDay == null) {
+            return;
+        } else if (firstDay.isAfter(lastDay)) {
             dispatchOnRangeSelected(lastDay, firstDay);
         } else {
             dispatchOnRangeSelected(firstDay, lastDay);


### PR DESCRIPTION
While inflating the MaterialCalendarView from xml, sometimes it crashes on same devices
xml:

`<com.prolificinteractive.materialcalendarview.MaterialCalendarView
                        android:id="@+id/mcv_filter_range"
                        android:layout_width="match_parent"
                        android:layout_height="wrap_content"
                        app:mcv_selectionColor="@color/blue_theme" />`

Stack trace:

`Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean xv.b(xv)' on a null object reference  at com.prolificinteractive.materialcalendarview.MaterialCalendarView.selectRange(SourceFile:1471)`