### PR TITLE
Allow set formatted day content description

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
@@ -37,6 +37,7 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
     private List<CalendarDay> selectedDates = new ArrayList<>();
     private WeekDayFormatter weekDayFormatter = WeekDayFormatter.DEFAULT;
     private DayFormatter dayFormatter = DayFormatter.DEFAULT;
+    private DayFormatter dayFormatterContentDescription = dayFormatter;
     private List<DayViewDecorator> decorators = new ArrayList<>();
     private List<DecoratorResult> decoratorResults = null;
     private boolean selectionEnabled = true;
@@ -89,6 +90,7 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
         newAdapter.selectedDates = selectedDates;
         newAdapter.weekDayFormatter = weekDayFormatter;
         newAdapter.dayFormatter = dayFormatter;
+        newAdapter.dayFormatterContentDescription = dayFormatterContentDescription;
         newAdapter.decorators = decorators;
         newAdapter.decoratorResults = decoratorResults;
         newAdapter.selectionEnabled = selectionEnabled;
@@ -143,6 +145,7 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
 
         pagerView.setWeekDayFormatter(weekDayFormatter);
         pagerView.setDayFormatter(dayFormatter);
+        pagerView.setDayFormatterContentDescription(dayFormatterContentDescription);
         if (color != null) {
             pagerView.setSelectionColor(color);
         }
@@ -220,6 +223,8 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
     }
 
     public void setDayFormatter(DayFormatter formatter) {
+        dayFormatterContentDescription = dayFormatterContentDescription == dayFormatter ?
+                formatter : dayFormatterContentDescription;
         this.dayFormatter = formatter;
         for (V pagerView : currentViews) {
             pagerView.setDayFormatter(formatter);
@@ -227,6 +232,7 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
     }
 
     public void setDayFormatterContentDescription(DayFormatter formatter) {
+        dayFormatterContentDescription = formatter;
         for (V pagerView : currentViews) {
             pagerView.setDayFormatterContentDescription(formatter);
         }

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
@@ -226,6 +226,12 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
         }
     }
 
+    public void setDayFormatterContentDescription(DayFormatter formatter) {
+        for (V pagerView : currentViews) {
+            pagerView.setDayFormatterContentDescription(formatter);
+        }
+    }
+
     @ShowOtherDates
     public int getShowOtherDates() {
         return showOtherDates;

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
@@ -145,6 +145,12 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
         }
     }
 
+    public void setDayFormatterContentDescription(DayFormatter formatter) {
+        for (DayView dayView : dayViews) {
+            dayView.setDayFormatter(formatter);
+        }
+    }
+
     public void setMinimumDate(CalendarDay minDate) {
         this.minDate = minDate;
         updateUi();

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
@@ -147,7 +147,7 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
 
     public void setDayFormatterContentDescription(DayFormatter formatter) {
         for (DayView dayView : dayViews) {
-            dayView.setDayFormatter(formatter);
+            dayView.setDayFormatterContentDescription(formatter);
         }
     }
 

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
@@ -43,6 +43,7 @@ class DayView extends CheckedTextView {
     private Drawable selectionDrawable;
     private Drawable mCircleDrawable;
     private DayFormatter formatter = DayFormatter.DEFAULT;
+    private DayFormatter contentDescriptionFormatter = formatter;
 
     private boolean isInRange = true;
     private boolean isInMonth = true;
@@ -77,6 +78,8 @@ class DayView extends CheckedTextView {
      * @param formatter new label formatter
      */
     public void setDayFormatter(DayFormatter formatter) {
+        this.contentDescriptionFormatter = contentDescriptionFormatter == this.formatter ?
+                formatter : contentDescriptionFormatter;
         this.formatter = formatter == null ? DayFormatter.DEFAULT : formatter;
         CharSequence currentLabel = getText();
         Object[] spans = null;
@@ -92,9 +95,35 @@ class DayView extends CheckedTextView {
         setText(newLabel);
     }
 
+    /**
+     * Set the new content description formatter and reformat the current content description.
+     *
+     * @param formatter new content description formatter
+     */
+    public void setDayFormatterContentDescription(DayFormatter formatter) {
+        this.contentDescriptionFormatter = formatter == null ? this.formatter : formatter;
+        CharSequence currentContentDescriptionLabel = getContentDescription();
+        Object[] spans = null;
+        if (currentContentDescriptionLabel instanceof Spanned) {
+            spans = ((Spanned) currentContentDescriptionLabel).getSpans(0, currentContentDescriptionLabel.length(), Object.class);
+        }
+        SpannableString newContentDescriptionLabel = new SpannableString(getContentDescriptionLabel());
+        if (spans != null) {
+            for (Object span : spans) {
+                newContentDescriptionLabel.setSpan(span, 0, newContentDescriptionLabel.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+        }
+        setContentDescription(newContentDescriptionLabel);
+    }
+
     @NonNull
     public String getLabel() {
         return formatter.format(date);
+    }
+
+    @NonNull
+    public String getContentDescriptionLabel() {
+        return contentDescriptionFormatter == null ? formatter.format(date) : contentDescriptionFormatter.format(date);
     }
 
     public void setSelectionColor(int color) {

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
@@ -102,18 +102,7 @@ class DayView extends CheckedTextView {
      */
     public void setDayFormatterContentDescription(DayFormatter formatter) {
         this.contentDescriptionFormatter = formatter == null ? this.formatter : formatter;
-        CharSequence currentContentDescriptionLabel = getContentDescription();
-        Object[] spans = null;
-        if (currentContentDescriptionLabel instanceof Spanned) {
-            spans = ((Spanned) currentContentDescriptionLabel).getSpans(0, currentContentDescriptionLabel.length(), Object.class);
-        }
-        SpannableString newContentDescriptionLabel = new SpannableString(getContentDescriptionLabel());
-        if (spans != null) {
-            for (Object span : spans) {
-                newContentDescriptionLabel.setSpan(span, 0, newContentDescriptionLabel.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-            }
-        }
-        setContentDescription(newContentDescriptionLabel);
+        setContentDescription(getContentDescriptionLabel());
     }
 
     @NonNull

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -708,6 +708,15 @@ public class MaterialCalendarView extends ViewGroup {
     }
 
     /**
+     * Set a formatter for day content description.
+     *
+     * @param formatter the new formatter, null for default
+     */
+    public void setDayFormatterContentDescription(DayFormatter formatter) {
+        adapter.setDayFormatterContentDescription(formatter);
+    }
+
+    /**
      * @return icon used for the left arrow
      */
     public Drawable getLeftArrowMask() {


### PR DESCRIPTION
Allows setting a custom content description for the day. For example, to get a similar content description to the one which comes with the stock Android CalendarView, just do:

```java
DateFormatDayFormatter formatter = new DateFormatDayFormatter(new SimpleDateFormat("d MMM yyyy", Locale.getDefault()));
widget.setDayFormatterContentDescription(formatter);
```