### PR TITLE
issue #857 Background duplication problem

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
@@ -190,7 +190,7 @@ import static com.prolificinteractive.materialcalendarview.MaterialCalendarView.
 
   @Override
   protected void onDraw(@NonNull Canvas canvas) {
-    if (customBackground != null) {
+    if (customBackground != null && !isChecked()) {
       customBackground.setBounds(tempRect);
       customBackground.setState(getDrawableState());
       customBackground.draw(canvas);
@@ -201,8 +201,14 @@ import static com.prolificinteractive.materialcalendarview.MaterialCalendarView.
     super.onDraw(canvas);
   }
 
+  @Override
+  public void setChecked(boolean checked) {
+    super.setChecked(checked);
+    regenerateBackground();
+  }
+
   private void regenerateBackground() {
-    if (selectionDrawable != null) {
+    if (selectionDrawable != null && isChecked()) {
       setBackgroundDrawable(selectionDrawable);
     } else {
       mCircleDrawable = generateBackground(selectionColor, fadeTime, circleDrawableRect);


### PR DESCRIPTION
If both setSelectionDrawable and setBackgroundDrawable are used, the drawable section is placed after the background drawing.
Fixed a problem by checking whether it was selected.