### PR TITLE
Feature - Colorize date text throught DayViewFacade

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/DayView.java
@@ -262,7 +262,12 @@ import static com.prolificinteractive.materialcalendarview.MaterialCalendarView.
 
     setCustomBackground(facade.getBackgroundDrawable());
     setSelectionDrawable(facade.getSelectionDrawable());
-
+  
+    Integer textColor = facade.getTextColor();
+    if (textColor != null) {
+      setTextColor(facade.getTextColor());
+    }
+    
     // Facade has spans
     List<DayViewFacade.Span> spans = facade.getSpans();
     if (!spans.isEmpty()) {

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/DayViewFacade.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/DayViewFacade.java
@@ -1,7 +1,9 @@
 package com.prolificinteractive.materialcalendarview;
 
 import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -13,6 +15,8 @@ public class DayViewFacade {
 
   private boolean isDecorated;
 
+  @ColorInt
+  private Integer textColor = null;
   private Drawable backgroundDrawable = null;
   private Drawable selectionDrawable = null;
   private final LinkedList<Span> spans = new LinkedList<>();
@@ -21,7 +25,17 @@ public class DayViewFacade {
   DayViewFacade() {
     isDecorated = false;
   }
-
+  
+  /**
+   * Set the color of the text
+   *
+   * @param color Color of the text
+   */
+  public void setTextColor(@ColorInt int color) {
+    this.textColor = color;
+    isDecorated = true;
+  }
+  
   /**
    * Set a drawable to draw behind everything else
    *
@@ -74,6 +88,7 @@ public class DayViewFacade {
   }
 
   void reset() {
+    textColor = null;
     backgroundDrawable = null;
     selectionDrawable = null;
     spans.clear();
@@ -87,6 +102,9 @@ public class DayViewFacade {
    * @param other facade to apply our data to
    */
   void applyTo(DayViewFacade other) {
+    if (textColor != null) {
+      other.textColor = textColor;
+    }
     if (selectionDrawable != null) {
       other.setSelectionDrawable(selectionDrawable);
     }
@@ -101,7 +119,13 @@ public class DayViewFacade {
   boolean isDecorated() {
     return isDecorated;
   }
-
+  
+  @Nullable
+  @ColorInt
+  public Integer getTextColor() {
+    return textColor;
+  }
+  
   Drawable getSelectionDrawable() {
     return selectionDrawable;
   }


### PR DESCRIPTION
With extensive use of Decorators, the "dual state" of the date text coloration isn't enough for complex use cases. 

The PR solves this problem by adding a way to colorize the text through the DayViewFacade. 