### PR TITLE
Fix exceptions causing render to fail in the layout editor.

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -27,6 +27,7 @@ import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import com.jakewharton.threetenabp.AndroidThreeTen;
 import com.prolificinteractive.materialcalendarview.format.ArrayWeekDayFormatter;
 import com.prolificinteractive.materialcalendarview.format.DayFormatter;
 import com.prolificinteractive.materialcalendarview.format.MonthArrayTitleFormatter;
@@ -249,6 +250,10 @@ public class MaterialCalendarView extends ViewGroup {
   public MaterialCalendarView(Context context, AttributeSet attrs) {
     super(context, attrs);
 
+    if (isInEditMode()) {
+      AndroidThreeTen.init(context);
+    }
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
       //If we're on good Android versions, turn off clipping for cool effects
       setClipToPadding(false);
@@ -430,6 +435,10 @@ public class MaterialCalendarView extends ViewGroup {
   }
 
   private void updateUi() {
+    if (isInEditMode()) {
+      titleChanger.setPreviousMonth(currentMonth);
+    }
+
     titleChanger.change(currentMonth);
     enableView(buttonPast, canGoBack());
     enableView(buttonFuture, canGoForward());


### PR DESCRIPTION
My attempt at fixing #876 

The main cause with calendarMode not being set was that an exception was occurring inside the state setup in the constructor, this exception was being swallowed by the try-catch block surrounding the setup logic.

The exception that was occurring in the state setup was the ThreeTen missing zone data one. By calling `AndroidThreeTen.init(context)` for edit mode at the beginning of the constructor this exception can be prevented.

Another exception that was occurring was due to a null `previousMonth` in the `TitleChanger`.

While this PR results in the calendar displaying in the layout editor, the dates displayed aren't a complete representation of the month, and the calendar mode isn't properly honoured.