### PR TITLE
Allow top bar visibility to be configured in XML, reflecting in preview

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -315,6 +315,11 @@ public class MaterialCalendarView extends ViewGroup {
           .setShowWeekDays(showWeekDays)
           .commit();
 
+      setTopbarVisible(a.getBoolean(
+              R.styleable.MaterialCalendarView_mcv_topBarVisible,
+              true
+      ));
+
       setSelectionMode(a.getInteger(
           R.styleable.MaterialCalendarView_mcv_selectionMode,
           SELECTION_MODE_SINGLE

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -65,6 +65,8 @@
       <enum name="vertical" value="0"/>
       <enum name="horizontal" value="1"/>
     </attr>
+
+    <attr name="mcv_topBarVisible" format="boolean"/>
   </declare-styleable>
 
 </resources>


### PR DESCRIPTION
Add a new attribute for specifying the top bar visibility so that the layout preview can be seen with the correct top bar state.

Layout preview itself is fixed in #967 