### PR TITLE
print the current date in old Calendar

### DIFF
--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/OldCalendarViewActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/OldCalendarViewActivity.java
@@ -1,6 +1,5 @@
 package com.prolificinteractive.materialcalendarview.sample;
 
-import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.CalendarView;

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/OldCalendarViewActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/OldCalendarViewActivity.java
@@ -1,5 +1,6 @@
 package com.prolificinteractive.materialcalendarview.sample;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.CalendarView;
@@ -28,6 +29,8 @@ public class OldCalendarViewActivity extends AppCompatActivity
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_old_calendarview);
     ButterKnife.bind(this);
+
+    textView.setText(FORMATTER.format(widget.getDate()));
 
     widget.setOnDateChangeListener(this);
   }


### PR DESCRIPTION
When enter the old calendar, the current date did not appear immediately. This has been corrected.