### PR TITLE
Feature - Change week day text gravity

### DIFF
--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerAdapter.java
@@ -3,17 +3,21 @@ package com.prolificinteractive.materialcalendarview;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.view.PagerAdapter;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+
 import com.prolificinteractive.materialcalendarview.MaterialCalendarView.ShowOtherDates;
 import com.prolificinteractive.materialcalendarview.format.DayFormatter;
 import com.prolificinteractive.materialcalendarview.format.TitleFormatter;
 import com.prolificinteractive.materialcalendarview.format.WeekDayFormatter;
+
+import org.threeten.bp.LocalDate;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.threeten.bp.LocalDate;
 
 /**
  * Pager adapter backing the calendar view
@@ -36,6 +40,7 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
   private DateRangeIndex rangeIndex;
   private List<CalendarDay> selectedDates = new ArrayList<>();
   private WeekDayFormatter weekDayFormatter = WeekDayFormatter.DEFAULT;
+  private int weekDayGravity = Gravity.CENTER;
   private DayFormatter dayFormatter = DayFormatter.DEFAULT;
   private DayFormatter dayFormatterContentDescription = dayFormatter;
   private List<DayViewDecorator> decorators = new ArrayList<>();
@@ -90,6 +95,7 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
     newAdapter.maxDate = maxDate;
     newAdapter.selectedDates = selectedDates;
     newAdapter.weekDayFormatter = weekDayFormatter;
+    newAdapter.weekDayGravity = weekDayGravity;
     newAdapter.dayFormatter = dayFormatter;
     newAdapter.dayFormatterContentDescription = dayFormatterContentDescription;
     newAdapter.decorators = decorators;
@@ -156,6 +162,7 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
     if (weekDayTextAppearance != null) {
       pagerView.setWeekDayTextAppearance(weekDayTextAppearance);
     }
+    pagerView.setWeekDayTextGravity(weekDayGravity);
     pagerView.setShowOtherDates(showOtherDates);
     pagerView.setMinimumDate(minDate);
     pagerView.setMaximumDate(maxDate);
@@ -259,6 +266,13 @@ abstract class CalendarPagerAdapter<V extends CalendarPagerView> extends PagerAd
     this.weekDayTextAppearance = taId;
     for (V pagerView : currentViews) {
       pagerView.setWeekDayTextAppearance(taId);
+    }
+  }
+
+  public void setWeekDayTextGravity(int gravity) {
+    this.weekDayGravity = gravity;
+    for (V pagerView : currentViews) {
+      pagerView.setWeekDayTextGravity(gravity);
     }
   }
 

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/CalendarPagerView.java
@@ -7,16 +7,19 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
+
 import com.prolificinteractive.materialcalendarview.MaterialCalendarView.ShowOtherDates;
 import com.prolificinteractive.materialcalendarview.format.DayFormatter;
 import com.prolificinteractive.materialcalendarview.format.WeekDayFormatter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+
 import org.threeten.bp.DayOfWeek;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.temporal.TemporalField;
 import org.threeten.bp.temporal.WeekFields;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import static com.prolificinteractive.materialcalendarview.MaterialCalendarView.SHOW_DEFAULTS;
 import static com.prolificinteractive.materialcalendarview.MaterialCalendarView.showOtherMonths;
@@ -115,6 +118,13 @@ abstract class CalendarPagerView extends ViewGroup
   public void setWeekDayTextAppearance(int taId) {
     for (WeekDayView weekDayView : weekDayViews) {
       weekDayView.setTextAppearance(getContext(), taId);
+    }
+  }
+
+  public void setWeekDayTextGravity(int gravity) {
+    for (WeekDayView weekDayView : weekDayViews) {
+      weekDayView.setGravity(gravity);
+      weekDayView.invalidate();
     }
   }
 

--- a/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
+++ b/library/src/main/java/com/prolificinteractive/materialcalendarview/MaterialCalendarView.java
@@ -750,6 +750,10 @@ public class MaterialCalendarView extends ViewGroup {
     adapter.setWeekDayTextAppearance(resourceId);
   }
 
+  public void setWeekDayTextGravity(int gravity) {
+    adapter.setWeekDayTextGravity(gravity);
+  }
+
   /**
    * Get the currently selected date, or null if no selection. Depending on the selection mode,
    * you might get different results.

--- a/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/CustomizeCodeActivity.java
+++ b/sample/src/main/java/com/prolificinteractive/materialcalendarview/sample/CustomizeCodeActivity.java
@@ -3,14 +3,18 @@ package com.prolificinteractive.materialcalendarview.sample;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.TypedValue;
-import butterknife.BindView;
-import butterknife.ButterKnife;
+import android.view.Gravity;
+
 import com.prolificinteractive.materialcalendarview.CalendarDay;
 import com.prolificinteractive.materialcalendarview.CalendarMode;
 import com.prolificinteractive.materialcalendarview.MaterialCalendarView;
 import com.prolificinteractive.materialcalendarview.format.ArrayWeekDayFormatter;
 import com.prolificinteractive.materialcalendarview.format.MonthArrayTitleFormatter;
+
 import org.threeten.bp.DayOfWeek;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
 
 public class CustomizeCodeActivity extends AppCompatActivity {
 
@@ -28,6 +32,7 @@ public class CustomizeCodeActivity extends AppCompatActivity {
     widget.setRightArrow(R.drawable.ic_arrow_forward);
     widget.setSelectionColor(getResources().getColor(R.color.sample_primary));
     widget.setWeekDayTextAppearance(R.style.CustomTextAppearance);
+    widget.setWeekDayTextGravity(Gravity.BOTTOM);
     widget.setHeaderTextAppearance(R.style.CustomTextAppearance);
     widget.setDateTextAppearance(R.style.CustomTextAppearance);
     widget.setTitleFormatter(new MonthArrayTitleFormatter(getResources().getTextArray(R.array.custom_months)));


### PR DESCRIPTION
In the tiny added change user can change the text gravity of weekdays.

Currently, both weeks header and days headers have the same height and that makes a large spacing between the week's header and the first row of the calendar (weekly or monthly), to fix that user can change the gravity of the weeks' header to BOTTOM using:
```
widget.setWeekDayTextGravity(Gravity.BOTTOM);
```